### PR TITLE
feat: Add TODO creation functionality

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { Container, Paper, Stack, Title } from '@mantine/core'
 
 import type { Todo } from '@/types/todo'
 
+import { TodoAddForm } from '@/components/todo-add-form'
 import { TodoList } from '@/components/todo-list'
 import { useTodoStore } from '@/stores/todo-store'
 
@@ -56,7 +57,10 @@ export default function HomePage() {
           <Title mb="lg" order={1} ta="center">
             Think Harder TODO App
           </Title>
-          <TodoList />
+          <Stack gap="lg">
+            <TodoAddForm />
+            <TodoList />
+          </Stack>
         </Paper>
       </Stack>
     </Container>

--- a/components/todo-add-form.tsx
+++ b/components/todo-add-form.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { Button, Stack, Textarea, TextInput } from '@mantine/core'
+import { useForm, zodResolver } from '@mantine/form'
+
+import type { CreateTodoInput } from '@/types/todo'
+
+import { createTodoInputSchema } from '@/schemas/todo'
+import { useTodoStore } from '@/stores/todo-store'
+
+/**
+ * TODO項目を追加するフォームコンポーネント
+ *
+ * @description
+ * ユーザーが新しいTODO項目を追加するためのフォームを提供します。
+ * タイトル（必須）と説明（任意）を入力できます。
+ *
+ * @example
+ * ```tsx
+ * <TodoAddForm />
+ * ```
+ */
+export function TodoAddForm() {
+  const addTodo = useTodoStore((state) => state.addTodo)
+
+  const form = useForm<CreateTodoInput>({
+    initialValues: {
+      description: '',
+      title: '',
+    },
+    validate: zodResolver(createTodoInputSchema),
+  })
+
+  /**
+   * フォーム送信時の処理
+   *
+   * @param values - フォームの値
+   */
+  function handleSubmit(values: CreateTodoInput) {
+    addTodo(values)
+    form.reset()
+  }
+
+  /**
+   * Enterキー押下時の処理
+   *
+   * @param event - キーボードイベント
+   */
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      form.onSubmit(handleSubmit)()
+    }
+  }
+
+  return (
+    <form onSubmit={form.onSubmit(handleSubmit)}>
+      <Stack gap="md">
+        <TextInput
+          label="タイトル"
+          placeholder="TODO のタイトルを入力してください"
+          required
+          {...form.getInputProps('title')}
+          onKeyDown={handleKeyDown}
+        />
+        <Textarea
+          label="説明"
+          placeholder="TODO の説明を入力してください（任意）"
+          {...form.getInputProps('description')}
+        />
+        <Button type="submit">TODO を追加</Button>
+      </Stack>
+    </form>
+  )
+}

--- a/tests/components/todo-add-form.test.tsx
+++ b/tests/components/todo-add-form.test.tsx
@@ -1,0 +1,171 @@
+import { MantineProvider } from '@mantine/core'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+
+import { TodoAddForm } from '@/components/todo-add-form'
+import { useTodoStore } from '@/stores/todo-store'
+
+/**
+ * MantineProviderでラップしたカスタムrender関数
+ */
+function renderWithMantine(ui: React.ReactElement) {
+  return render(<MantineProvider>{ui}</MantineProvider>)
+}
+
+// Zustand ストアをモック
+vi.mock('@/stores/todo-store', () => ({
+  useTodoStore: vi.fn(),
+}))
+
+describe('TodoAddForm', () => {
+  const mockAddTodo = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useTodoStore).mockImplementation((selector) => {
+      const state = {
+        addTodo: mockAddTodo,
+        deleteTodo: vi.fn(),
+        getAllTodos: vi.fn(),
+        getCompletedTodos: vi.fn(),
+        getPendingTodos: vi.fn(),
+        getTodoById: vi.fn(),
+        initializeTodos: vi.fn(),
+        isLoading: false,
+        todos: [],
+        toggleTodoStatus: vi.fn(),
+        updateTodo: vi.fn(),
+      }
+      return selector(state)
+    })
+  })
+
+  // 基本的なレンダリングテスト
+  it('renders todo add form with all required fields', () => {
+    renderWithMantine(<TodoAddForm />)
+
+    expect(
+      screen.getByRole('textbox', { name: /タイトル/ })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: /説明/ })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'TODO を追加' })
+    ).toBeInTheDocument()
+  })
+
+  // フォームの入力テスト
+  it('allows user to enter title and description', () => {
+    renderWithMantine(<TodoAddForm />)
+
+    const titleInput = screen.getByRole('textbox', { name: /タイトル/ })
+    const descriptionInput = screen.getByRole('textbox', { name: /説明/ })
+
+    fireEvent.change(titleInput, { target: { value: 'テストタイトル' } })
+    fireEvent.change(descriptionInput, { target: { value: 'テスト説明' } })
+
+    expect(titleInput).toHaveValue('テストタイトル')
+    expect(descriptionInput).toHaveValue('テスト説明')
+  })
+
+  // バリデーションテスト - 必須フィールド
+  it('does not call addTodo when title is empty', async () => {
+    renderWithMantine(<TodoAddForm />)
+
+    const submitButton = screen.getByRole('button', { name: 'TODO を追加' })
+
+    fireEvent.click(submitButton)
+
+    // addTodo が呼ばれないことを確認
+    expect(mockAddTodo).not.toHaveBeenCalled()
+  })
+
+  // バリデーションテスト - 文字数制限
+  it('shows validation error when title is too long', async () => {
+    renderWithMantine(<TodoAddForm />)
+
+    const titleInput = screen.getByRole('textbox', { name: /タイトル/ })
+    const longTitle = 'a'.repeat(101) // 101文字
+
+    fireEvent.change(titleInput, { target: { value: longTitle } })
+    fireEvent.click(screen.getByRole('button', { name: 'TODO を追加' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('タイトルは100文字以内で入力してください')
+      ).toBeInTheDocument()
+    })
+
+    expect(mockAddTodo).not.toHaveBeenCalled()
+  })
+
+  // 正常な送信テスト
+  it('calls addTodo with correct data when form is submitted', async () => {
+    renderWithMantine(<TodoAddForm />)
+
+    const titleInput = screen.getByRole('textbox', { name: /タイトル/ })
+    const descriptionInput = screen.getByRole('textbox', { name: /説明/ })
+
+    fireEvent.change(titleInput, { target: { value: 'テストタイトル' } })
+    fireEvent.change(descriptionInput, { target: { value: 'テスト説明' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'TODO を追加' }))
+
+    await waitFor(() => {
+      expect(mockAddTodo).toHaveBeenCalledWith({
+        description: 'テスト説明',
+        title: 'テストタイトル',
+      })
+    })
+  })
+
+  // フォームリセットテスト
+  it('resets form after successful submission', async () => {
+    renderWithMantine(<TodoAddForm />)
+
+    const titleInput = screen.getByRole('textbox', { name: /タイトル/ })
+    const descriptionInput = screen.getByRole('textbox', { name: /説明/ })
+
+    fireEvent.change(titleInput, { target: { value: 'テストタイトル' } })
+    fireEvent.change(descriptionInput, { target: { value: 'テスト説明' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'TODO を追加' }))
+
+    await waitFor(() => {
+      expect(titleInput).toHaveValue('')
+      expect(descriptionInput).toHaveValue('')
+    })
+  })
+
+  // 説明なしの送信テスト
+  it('allows submission with only title', async () => {
+    renderWithMantine(<TodoAddForm />)
+
+    const titleInput = screen.getByRole('textbox', { name: /タイトル/ })
+    fireEvent.change(titleInput, { target: { value: 'タイトルのみ' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'TODO を追加' }))
+
+    await waitFor(() => {
+      expect(mockAddTodo).toHaveBeenCalledWith({
+        description: '',
+        title: 'タイトルのみ',
+      })
+    })
+  })
+
+  // エンターキーでの送信テスト
+  it('submits form when Enter key is pressed in title field', async () => {
+    renderWithMantine(<TodoAddForm />)
+
+    const titleInput = screen.getByRole('textbox', { name: /タイトル/ })
+    fireEvent.change(titleInput, { target: { value: 'エンターキーテスト' } })
+    fireEvent.keyDown(titleInput, { code: 'Enter', key: 'Enter' })
+
+    await waitFor(() => {
+      expect(mockAddTodo).toHaveBeenCalledWith({
+        description: '',
+        title: 'エンターキーテスト',
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- TODO追加フォームコンポーネント（TodoAddForm）を新規実装
- メインページにフォームを統合し、TODOの作成機能を追加
- TDDアプローチに従った包括的なテストスイートを実装

## Test plan
- [x] TODO追加フォームのレンダリングテスト
- [x] フォーム入力の動作テスト 
- [x] バリデーション機能のテスト
- [x] フォーム送信処理のテスト
- [x] キーボードナビゲーション（Enterキー）のテスト
- [x] エラーハンドリングのテスト
- [x] 全テストスイートの実行確認
- [x] 型チェック・リント・ビルドの確認

🤖 Generated with [Claude Code](https://claude.ai/code)