### PR TITLE
fix: Replace crypto.randomUUID() with cross-platform UUID utility

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * UUID v4を生成する関数
+ * crypto.randomUUID()が利用可能な場合はそれを使用し、
+ * 利用できない場合は代替実装を使用する
+ * @returns 生成されたUUID v4文字列
+ */
+export function generateUUID(): string {
+  // crypto.randomUUID()が利用可能な場合は使用
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+
+  // 代替実装: UUID v4の生成
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replaceAll(/[xy]/g, (c) => {
+    const r = Math.trunc(Math.random() * 16)
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}

--- a/stores/todo-store.ts
+++ b/stores/todo-store.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand'
 
 import type { CreateTodoInput, Todo, UpdateTodoInput } from '@/types/todo'
 
+import { generateUUID } from '@/lib/utils'
+
 /**
  * TODO項目の状態管理を行うストアの型定義
  */
@@ -49,7 +51,7 @@ export const useTodoStore = create<TodoStore>((set, get) => ({
     const newTodo: Todo = {
       createdAt: now,
       description: input.description,
-      id: crypto.randomUUID(),
+      id: generateUUID(),
       status: 'pending',
       title: input.title,
       updatedAt: now,

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateUUID } from '@/lib/utils'
+
+describe('utils', () => {
+  describe('generateUUID', () => {
+    it('should generate a string', () => {
+      // Arrange & Act
+      const result = generateUUID()
+
+      // Assert
+      expect(typeof result).toBe('string')
+    })
+
+    it('should generate a UUID with correct format', () => {
+      // Arrange
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+      // Act
+      const result = generateUUID()
+
+      // Assert
+      expect(result).toMatch(uuidRegex)
+    })
+
+    it('should generate unique UUIDs', () => {
+      // Arrange & Act
+      const uuid1 = generateUUID()
+      const uuid2 = generateUUID()
+      const uuid3 = generateUUID()
+
+      // Assert
+      expect(uuid1).not.toBe(uuid2)
+      expect(uuid1).not.toBe(uuid3)
+      expect(uuid2).not.toBe(uuid3)
+    })
+
+    it('should generate UUID with correct length', () => {
+      // Arrange & Act
+      const result = generateUUID()
+
+      // Assert
+      expect(result.length).toBe(36)
+    })
+
+    it('should generate UUID with correct version (4)', () => {
+      // Arrange & Act
+      const result = generateUUID()
+
+      // Assert
+      expect(result.charAt(14)).toBe('4')
+    })
+
+    it('should generate UUID with correct variant', () => {
+      // Arrange & Act
+      const result = generateUUID()
+
+      // Assert
+      const variantChar = result.charAt(19)
+      expect(['8', '9', 'a', 'b', 'A', 'B']).toContain(variantChar)
+    })
+  })
+})

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -86,7 +86,9 @@ describe('utils', () => {
 
       it('should use fallback implementation when crypto is undefined', () => {
         // Arrange: Mock crypto to be undefined
-        vi.stubGlobal('crypto')
+        const originalCrypto = globalThis.crypto
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+        delete (globalThis as any).crypto
 
         // Act
         const result = generateUUID()
@@ -97,6 +99,9 @@ describe('utils', () => {
         expect(result.charAt(14)).toBe('4')
         const variantChar = result.charAt(19)
         expect(['8', '9', 'a', 'b', 'A', 'B']).toContain(variantChar)
+
+        // Cleanup
+        globalThis.crypto = originalCrypto
       })
 
       it('should use fallback implementation when crypto.randomUUID does not exist', () => {
@@ -116,7 +121,9 @@ describe('utils', () => {
 
       it('should generate unique UUIDs with fallback implementation', () => {
         // Arrange: Mock crypto to be undefined
-        vi.stubGlobal('crypto')
+        const originalCrypto = globalThis.crypto
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+        delete (globalThis as any).crypto
 
         // Act
         const uuid1 = generateUUID()
@@ -127,6 +134,9 @@ describe('utils', () => {
         expect(uuid1).not.toBe(uuid2)
         expect(uuid1).not.toBe(uuid3)
         expect(uuid2).not.toBe(uuid3)
+
+        // Cleanup
+        globalThis.crypto = originalCrypto
       })
     })
   })

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { generateUUID } from '@/lib/utils'
 
@@ -59,6 +59,75 @@ describe('utils', () => {
       // Assert
       const variantChar = result.charAt(19)
       expect(['8', '9', 'a', 'b', 'A', 'B']).toContain(variantChar)
+    })
+
+    describe('when crypto.randomUUID() is not available', () => {
+      afterEach(() => {
+        // Restore all stubbed globals
+        vi.unstubAllGlobals()
+      })
+
+      it('should use fallback implementation when crypto.randomUUID() is undefined', () => {
+        // Arrange: Mock crypto.randomUUID to be undefined
+        vi.stubGlobal('crypto', {
+          randomUUID: undefined,
+        })
+
+        // Act
+        const result = generateUUID()
+
+        // Assert
+        expect(typeof result).toBe('string')
+        expect(result.length).toBe(36)
+        expect(result.charAt(14)).toBe('4')
+        const variantChar = result.charAt(19)
+        expect(['8', '9', 'a', 'b', 'A', 'B']).toContain(variantChar)
+      })
+
+      it('should use fallback implementation when crypto is undefined', () => {
+        // Arrange: Mock crypto to be undefined
+        vi.stubGlobal('crypto')
+
+        // Act
+        const result = generateUUID()
+
+        // Assert
+        expect(typeof result).toBe('string')
+        expect(result.length).toBe(36)
+        expect(result.charAt(14)).toBe('4')
+        const variantChar = result.charAt(19)
+        expect(['8', '9', 'a', 'b', 'A', 'B']).toContain(variantChar)
+      })
+
+      it('should use fallback implementation when crypto.randomUUID does not exist', () => {
+        // Arrange: Mock crypto without randomUUID
+        vi.stubGlobal('crypto', {})
+
+        // Act
+        const result = generateUUID()
+
+        // Assert
+        expect(typeof result).toBe('string')
+        expect(result.length).toBe(36)
+        expect(result.charAt(14)).toBe('4')
+        const variantChar = result.charAt(19)
+        expect(['8', '9', 'a', 'b', 'A', 'B']).toContain(variantChar)
+      })
+
+      it('should generate unique UUIDs with fallback implementation', () => {
+        // Arrange: Mock crypto to be undefined
+        vi.stubGlobal('crypto')
+
+        // Act
+        const uuid1 = generateUUID()
+        const uuid2 = generateUUID()
+        const uuid3 = generateUUID()
+
+        // Assert
+        expect(uuid1).not.toBe(uuid2)
+        expect(uuid1).not.toBe(uuid3)
+        expect(uuid2).not.toBe(uuid3)
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary
- crypto.randomUUID() was causing runtime errors in environments where it's not available
- Created a generateUUID() utility function with fallback implementation using Math.random()
- Updated todo-store to use the new cross-platform UUID utility
- Added comprehensive tests for UUID generation with TDD approach

## Test plan
- [x] UUID utility tests pass (format, uniqueness, version 4 compliance)
- [x] Todo store tests pass with new UUID implementation
- [x] All existing tests continue to pass
- [x] Type checking passes
- [x] Lint checks pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)