### PR TITLE
fix: Update API routes to use async params in Next.js 15

### DIFF
--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -4,9 +4,9 @@ import * as todoService from '@/lib/todo-service'
 import { updateTodoInputSchema } from '@/schemas/todo'
 
 interface Params {
-  params: {
+  params: Promise<{
     id: string
-  }
+  }>
 }
 
 /**
@@ -14,7 +14,8 @@ interface Params {
  */
 export async function DELETE(request: Request, { params }: Params) {
   try {
-    await todoService.deleteTodo(params.id)
+    const { id } = await params
+    await todoService.deleteTodo(id)
     return new NextResponse(undefined, { status: 204 })
   } catch {
     return NextResponse.json(
@@ -29,7 +30,8 @@ export async function DELETE(request: Request, { params }: Params) {
  */
 export async function PATCH(request: Request, { params }: Params) {
   try {
-    const todo = await todoService.toggleTodo(params.id)
+    const { id } = await params
+    const todo = await todoService.toggleTodo(id)
     return NextResponse.json(todo)
   } catch {
     return NextResponse.json(
@@ -44,9 +46,10 @@ export async function PATCH(request: Request, { params }: Params) {
  */
 export async function PUT(request: Request, { params }: Params) {
   try {
+    const { id } = await params
     const body = (await request.json()) as unknown
     const validatedData = updateTodoInputSchema.parse(body)
-    const todo = await todoService.updateTodo(params.id, validatedData)
+    const todo = await todoService.updateTodo(id, validatedData)
     return NextResponse.json(todo)
   } catch {
     return NextResponse.json(

--- a/app/api/todos/[id]/toggle/route.ts
+++ b/app/api/todos/[id]/toggle/route.ts
@@ -7,10 +7,11 @@ import * as todoService from '@/lib/todo-service'
  */
 export async function POST(
   _request: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const todo = await todoService.toggleTodo(params.id)
+    const { id } = await params
+    const todo = await todoService.toggleTodo(id)
     return NextResponse.json(todo)
   } catch {
     return NextResponse.json(

--- a/tests/api/todos/[id]/route.test.ts
+++ b/tests/api/todos/[id]/route.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Todo } from '@/types/todo'
+
+import { DELETE, PATCH, PUT } from '@/app/api/todos/[id]/route'
+import * as todoService from '@/lib/todo-service'
+
+// Mock the todo service
+vi.mock('@/lib/todo-service')
+
+describe('/api/todos/[id] route', () => {
+  describe('DELETE', () => {
+    it('should delete a todo with awaited params', async () => {
+      // Arrange
+      const mockParams = Promise.resolve({ id: 'test-id' })
+      const mockRequest = new Request(
+        'http://localhost:3000/api/todos/test-id',
+        {
+          method: 'DELETE',
+        }
+      )
+      vi.mocked(todoService.deleteTodo).mockResolvedValueOnce()
+
+      // Act
+      const response = await DELETE(mockRequest, { params: mockParams })
+
+      // Assert
+      expect(response.status).toBe(204)
+      expect(todoService.deleteTodo).toHaveBeenCalledWith('test-id')
+    })
+
+    it('should return 400 when delete fails', async () => {
+      // Arrange
+      const mockParams = Promise.resolve({ id: 'test-id' })
+      const mockRequest = new Request(
+        'http://localhost:3000/api/todos/test-id',
+        {
+          method: 'DELETE',
+        }
+      )
+      vi.mocked(todoService.deleteTodo).mockRejectedValueOnce(
+        new Error('Delete failed')
+      )
+
+      // Act
+      const response = await DELETE(mockRequest, { params: mockParams })
+      const data = (await response.json()) as { error: string }
+
+      // Assert
+      expect(response.status).toBe(400)
+      expect(data).toEqual({ error: 'Failed to delete todo' })
+    })
+  })
+
+  describe('PATCH', () => {
+    it('should toggle todo completion with awaited params', async () => {
+      // Arrange
+      const mockParams = Promise.resolve({ id: 'test-id' })
+      const mockRequest = new Request(
+        'http://localhost:3000/api/todos/test-id',
+        {
+          method: 'PATCH',
+        }
+      )
+      const mockTodo = {
+        createdAt: new Date(),
+        id: 'test-id',
+        status: 'completed' as const,
+        title: 'Test Todo',
+        updatedAt: new Date(),
+      }
+      vi.mocked(todoService.toggleTodo).mockResolvedValueOnce(mockTodo)
+
+      // Act
+      const response = await PATCH(mockRequest, { params: mockParams })
+      const data = (await response.json()) as Todo
+
+      // Assert
+      expect(response.status).toBe(200)
+      expect(data).toEqual(mockTodo)
+      expect(todoService.toggleTodo).toHaveBeenCalledWith('test-id')
+    })
+
+    it('should return 400 when toggle fails', async () => {
+      // Arrange
+      const mockParams = Promise.resolve({ id: 'test-id' })
+      const mockRequest = new Request(
+        'http://localhost:3000/api/todos/test-id',
+        {
+          method: 'PATCH',
+        }
+      )
+      vi.mocked(todoService.toggleTodo).mockRejectedValueOnce(
+        new Error('Toggle failed')
+      )
+
+      // Act
+      const response = await PATCH(mockRequest, { params: mockParams })
+      const data = (await response.json()) as { error: string }
+
+      // Assert
+      expect(response.status).toBe(400)
+      expect(data).toEqual({ error: 'Failed to toggle todo' })
+    })
+  })
+
+  describe('PUT', () => {
+    it('should update todo with awaited params', async () => {
+      // Arrange
+      const mockParams = Promise.resolve({ id: 'test-id' })
+      const updateData = { title: 'Updated Todo' }
+      const mockRequest = new Request(
+        'http://localhost:3000/api/todos/test-id',
+        {
+          body: JSON.stringify(updateData),
+          method: 'PUT',
+        }
+      )
+      const mockTodo = {
+        createdAt: new Date(),
+        id: 'test-id',
+        status: 'pending' as const,
+        title: 'Updated Todo',
+        updatedAt: new Date(),
+      }
+      vi.mocked(todoService.updateTodo).mockResolvedValueOnce(mockTodo)
+
+      // Act
+      const response = await PUT(mockRequest, { params: mockParams })
+      const data = (await response.json()) as Todo
+
+      // Assert
+      expect(response.status).toBe(200)
+      expect(data).toEqual(mockTodo)
+      expect(todoService.updateTodo).toHaveBeenCalledWith('test-id', updateData)
+    })
+
+    it('should return 400 when update fails', async () => {
+      // Arrange
+      const mockParams = Promise.resolve({ id: 'test-id' })
+      const updateData = { title: 'Updated Todo' }
+      const mockRequest = new Request(
+        'http://localhost:3000/api/todos/test-id',
+        {
+          body: JSON.stringify(updateData),
+          method: 'PUT',
+        }
+      )
+      vi.mocked(todoService.updateTodo).mockRejectedValueOnce(
+        new Error('Update failed')
+      )
+
+      // Act
+      const response = await PUT(mockRequest, { params: mockParams })
+      const data = (await response.json()) as { error: string }
+
+      // Assert
+      expect(response.status).toBe(400)
+      expect(data).toEqual({ error: 'Failed to update todo' })
+    })
+  })
+})

--- a/tests/api/todos/[id]/toggle/route.test.ts
+++ b/tests/api/todos/[id]/toggle/route.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Todo } from '@/types/todo'
+
+import { POST } from '@/app/api/todos/[id]/toggle/route'
+import * as todoService from '@/lib/todo-service'
+
+// Mock the todo service
+vi.mock('@/lib/todo-service')
+
+describe('/api/todos/[id]/toggle route', () => {
+  describe('POST', () => {
+    it('should toggle todo completion with awaited params', async () => {
+      // Arrange
+      const mockParams = Promise.resolve({ id: 'test-id' })
+      const mockRequest = new Request(
+        'http://localhost:3000/api/todos/test-id/toggle',
+        {
+          method: 'POST',
+        }
+      )
+      const mockTodo = {
+        createdAt: new Date(),
+        id: 'test-id',
+        status: 'completed' as const,
+        title: 'Test Todo',
+        updatedAt: new Date(),
+      }
+      vi.mocked(todoService.toggleTodo).mockResolvedValueOnce(mockTodo)
+
+      // Act
+      const response = await POST(mockRequest, { params: mockParams })
+      const data = (await response.json()) as Todo
+
+      // Assert
+      expect(response.status).toBe(200)
+      expect(data).toEqual(mockTodo)
+      expect(todoService.toggleTodo).toHaveBeenCalledWith('test-id')
+    })
+
+    it('should return 404 when toggle fails', async () => {
+      // Arrange
+      const mockParams = Promise.resolve({ id: 'test-id' })
+      const mockRequest = new Request(
+        'http://localhost:3000/api/todos/test-id/toggle',
+        {
+          method: 'POST',
+        }
+      )
+      vi.mocked(todoService.toggleTodo).mockRejectedValueOnce(
+        new Error('Todo not found')
+      )
+
+      // Act
+      const response = await POST(mockRequest, { params: mockParams })
+      const data = (await response.json()) as { error: string }
+
+      // Assert
+      expect(response.status).toBe(404)
+      expect(data).toEqual({ error: 'Failed to toggle todo' })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Next.js 15で動的ルートのparamsがPromiseになったため、APIルートハンドラーを更新
- すべての動的ルートハンドラーでparamsをawaitするように修正
- TDDアプローチで包括的なテストを追加

## Changes
- `/app/api/todos/[id]/route.ts` - DELETE, PATCH, PUTメソッドを修正
- `/app/api/todos/[id]/toggle/route.ts` - POSTメソッドを修正
- TypeScript型定義を`params: Promise<{id: string}>`に更新
- 各APIルートハンドラーの完全なテストカバレッジを追加

## Test plan
- [x] すべてのAPIルートテストが成功することを確認
- [x] 既存のテストスイートがすべて成功することを確認
- [x] TypeScript型チェックが成功することを確認
- [x] ESLintチェックが成功することを確認
- [x] プロダクションビルドが成功することを確認

## Technical details
Next.js 15では、動的ルートセグメントのparamsが非同期になりました。これは、より効率的なルーティングとデータフェッチングを可能にするための変更です。

修正前:
```typescript
export async function DELETE(request: Request, { params }: { params: { id: string } }) {
  await todoService.deleteTodo(params.id)
}
```

修正後:
```typescript
export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
  const { id } = await params
  await todoService.deleteTodo(id)
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)