### PR TITLE
feat: TODOダッシュボード機能を追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 
 import { Container, Paper, Stack, Title } from '@mantine/core'
 
+import { TodoStatsDashboard } from '@/components/dashboard/todo-stats-dashboard'
 import { TodoAddForm } from '@/components/todo-add-form'
 import { TodoList } from '@/components/todo-list'
 import { useTodoStore } from '@/stores/todo-store'
@@ -22,10 +23,11 @@ export default function HomePage() {
   return (
     <Container py="xl" size="md">
       <Stack gap="xl">
+        <Title order={1} ta="center">
+          Think Harder TODO App
+        </Title>
+        <TodoStatsDashboard />
         <Paper p="xl" withBorder>
-          <Title mb="lg" order={1} ta="center">
-            Think Harder TODO App
-          </Title>
           <Stack gap="lg">
             <TodoAddForm />
             <TodoList />

--- a/components/dashboard/completion-progress.tsx
+++ b/components/dashboard/completion-progress.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { Paper, Progress, Stack, Text } from '@mantine/core'
+
+/**
+ * 完了進捗コンポーネントのプロパティ
+ */
+interface CompletionProgressProps {
+  /** 完了率（0-100の値） */
+  completionRate: number
+}
+
+/**
+ * TODO完了率を表示する進捗バーコンポーネント
+ *
+ * @description
+ * TODO項目の完了率をプログレスバーで視覚的に表示するコンポーネント。
+ * 完了率に応じて色分けを行い、アクセシビリティにも配慮している。
+ *
+ * @example
+ * ```tsx
+ * <CompletionProgress completionRate={75} />
+ * ```
+ */
+export function CompletionProgress({
+  completionRate,
+}: CompletionProgressProps) {
+  // 完了率を0-100の範囲に制限
+  const normalizedRate = Math.max(0, Math.min(100, completionRate))
+
+  const progressColor = getProgressColor(normalizedRate)
+
+  return (
+    <Paper p="md" withBorder>
+      <Stack gap="md">
+        <Text fw={500} size="sm" ta="center">
+          完了率
+        </Text>
+        <Progress
+          aria-label={`TODO完了進捗: ${normalizedRate}%`}
+          color={progressColor}
+          radius="md"
+          size="lg"
+          value={normalizedRate}
+        />
+        <Text c={progressColor} fw={700} size="lg" ta="center">
+          {normalizedRate}%
+        </Text>
+      </Stack>
+    </Paper>
+  )
+}
+
+/**
+ * 完了率に基づいて適切な色を決定する
+ */
+function getProgressColor(rate: number): string {
+  if (rate < 40) return 'red'
+  if (rate < 80) return 'yellow'
+  return 'green'
+}

--- a/components/dashboard/stats-card.tsx
+++ b/components/dashboard/stats-card.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { Paper, Stack, Text } from '@mantine/core'
+
+/**
+ * 統計カードコンポーネントのプロパティ
+ */
+interface StatsCardProps {
+  /** カードの色テーマ */
+  color?: string
+  /** 統計のラベル */
+  label: string
+  /** 統計の値 */
+  value: number
+}
+
+/**
+ * 統計情報を表示するカードコンポーネント
+ *
+ * @description
+ * TODO統計の数値を視覚的に表示するためのカードコンポーネント。
+ * ラベルと値をペアで表示し、色分けによる視覚的な区別が可能。
+ *
+ * @example
+ * ```tsx
+ * <StatsCard label="総TODO数" value={10} color="blue" />
+ * <StatsCard label="完了済み" value={7} color="green" />
+ * <StatsCard label="未完了" value={3} color="orange" />
+ * ```
+ */
+export function StatsCard({ color = 'blue', label, value }: StatsCardProps) {
+  return (
+    <Paper aria-label={`${label}: ${value}`} p="md" withBorder>
+      <Stack align="center" gap="xs">
+        <Text c="dimmed" size="sm" ta="center">
+          {label}
+        </Text>
+        <Text
+          c={color}
+          fw={700}
+          size="xl"
+          style={{ fontSize: '2rem' }}
+          ta="center"
+        >
+          {value}
+        </Text>
+      </Stack>
+    </Paper>
+  )
+}

--- a/components/dashboard/todo-stats-dashboard.tsx
+++ b/components/dashboard/todo-stats-dashboard.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { Paper, SimpleGrid, Stack, Title } from '@mantine/core'
+
+import { CompletionProgress } from './completion-progress'
+import { StatsCard } from './stats-card'
+
+import { useTodoStats } from '@/stores/todo-store'
+
+/**
+ * TODO統計ダッシュボードコンポーネント
+ *
+ * @description
+ * TODO項目の統計情報を視覚的に表示するダッシュボード。
+ * 総数、完了数、未完了数、完了率を分かりやすく表示する。
+ *
+ * @example
+ * ```tsx
+ * <TodoStatsDashboard />
+ * ```
+ */
+export function TodoStatsDashboard() {
+  const { completed, completionRate, pending, total } = useTodoStats()
+
+  return (
+    <section aria-label="TODO統計ダッシュボード" role="region">
+      <Paper p="xl" withBorder>
+        <Stack gap="lg">
+          <Title order={2} ta="center">
+            TODO統計
+          </Title>
+
+          <SimpleGrid
+            cols={{ base: 1, sm: 3 }}
+            data-testid="stats-cards-container"
+            spacing="md"
+          >
+            <StatsCard color="blue" label="総TODO数" value={total} />
+            <StatsCard color="green" label="完了済み" value={completed} />
+            <StatsCard color="orange" label="未完了" value={pending} />
+          </SimpleGrid>
+
+          <CompletionProgress completionRate={completionRate} />
+        </Stack>
+      </Paper>
+    </section>
+  )
+}

--- a/tests/components/dashboard/completion-progress.test.tsx
+++ b/tests/components/dashboard/completion-progress.test.tsx
@@ -1,0 +1,122 @@
+import { MantineProvider } from '@mantine/core'
+import { render, screen } from '@testing-library/react'
+
+import { CompletionProgress } from '@/components/dashboard/completion-progress'
+
+/**
+ * MantineProviderでラップしたカスタムrender関数
+ */
+function renderWithMantine(ui: React.ReactElement) {
+  return render(<MantineProvider>{ui}</MantineProvider>)
+}
+
+describe('CompletionProgress', () => {
+  describe('基本的な表示', () => {
+    it('完了率を表示する', () => {
+      // Arrange & Act
+      renderWithMantine(<CompletionProgress completionRate={75} />)
+
+      // Assert
+      expect(screen.getByText('完了率')).toBeInTheDocument()
+      expect(screen.getByText('75%')).toBeInTheDocument()
+    })
+
+    it('完了率0%を表示する', () => {
+      // Arrange & Act
+      renderWithMantine(<CompletionProgress completionRate={0} />)
+
+      // Assert
+      expect(screen.getByText('完了率')).toBeInTheDocument()
+      expect(screen.getByText('0%')).toBeInTheDocument()
+    })
+
+    it('完了率100%を表示する', () => {
+      // Arrange & Act
+      renderWithMantine(<CompletionProgress completionRate={100} />)
+
+      // Assert
+      expect(screen.getByText('完了率')).toBeInTheDocument()
+      expect(screen.getByText('100%')).toBeInTheDocument()
+    })
+  })
+
+  describe('プログレスバー', () => {
+    it('正しい完了率でプログレスバーを表示する', () => {
+      // Arrange & Act
+      renderWithMantine(<CompletionProgress completionRate={60} />)
+
+      // Assert
+      const progressBar = screen.getByRole('progressbar')
+      expect(progressBar).toBeInTheDocument()
+      expect(progressBar).toHaveAttribute('aria-valuenow', '60')
+      expect(progressBar).toHaveAttribute('aria-valuemax', '100')
+      expect(progressBar).toHaveAttribute('aria-valuemin', '0')
+    })
+
+    it('完了率に応じて適切な色を表示する', () => {
+      // Arrange & Act - 低い完了率
+      const { rerender } = renderWithMantine(
+        <CompletionProgress completionRate={25} />
+      )
+
+      // Assert - プログレスバーの存在確認
+      let progressBar = screen.getByRole('progressbar')
+      expect(progressBar).toBeInTheDocument()
+
+      // Act - 中程度の完了率
+      rerender(
+        <MantineProvider>
+          <CompletionProgress completionRate={60} />
+        </MantineProvider>
+      )
+
+      // Assert - プログレスバーの存在確認
+      progressBar = screen.getByRole('progressbar')
+      expect(progressBar).toBeInTheDocument()
+
+      // Act - 高い完了率
+      rerender(
+        <MantineProvider>
+          <CompletionProgress completionRate={90} />
+        </MantineProvider>
+      )
+
+      // Assert - プログレスバーの存在確認
+      progressBar = screen.getByRole('progressbar')
+      expect(progressBar).toBeInTheDocument()
+    })
+  })
+
+  describe('境界値テスト', () => {
+    it('完了率が負の値の場合、0として扱う', () => {
+      // Arrange & Act
+      renderWithMantine(<CompletionProgress completionRate={-10} />)
+
+      // Assert
+      const progressBar = screen.getByRole('progressbar')
+      expect(progressBar).toHaveAttribute('aria-valuenow', '0')
+      expect(screen.getByText('0%')).toBeInTheDocument()
+    })
+
+    it('完了率が100を超える場合、100として扱う', () => {
+      // Arrange & Act
+      renderWithMantine(<CompletionProgress completionRate={150} />)
+
+      // Assert
+      const progressBar = screen.getByRole('progressbar')
+      expect(progressBar).toHaveAttribute('aria-valuenow', '100')
+      expect(screen.getByText('100%')).toBeInTheDocument()
+    })
+  })
+
+  describe('アクセシビリティ', () => {
+    it('適切なaria-labelを持つ', () => {
+      // Arrange & Act
+      renderWithMantine(<CompletionProgress completionRate={75} />)
+
+      // Assert
+      const progressBar = screen.getByRole('progressbar')
+      expect(progressBar).toHaveAttribute('aria-label', 'TODO完了進捗: 75%')
+    })
+  })
+})

--- a/tests/components/dashboard/stats-card.test.tsx
+++ b/tests/components/dashboard/stats-card.test.tsx
@@ -1,0 +1,87 @@
+import { MantineProvider } from '@mantine/core'
+import { render, screen } from '@testing-library/react'
+
+import { StatsCard } from '@/components/dashboard/stats-card'
+
+/**
+ * MantineProviderでラップしたカスタムrender関数
+ */
+function renderWithMantine(ui: React.ReactElement) {
+  return render(<MantineProvider>{ui}</MantineProvider>)
+}
+
+describe('StatsCard', () => {
+  describe('基本的な表示', () => {
+    it('ラベルと値を表示する', () => {
+      // Arrange & Act
+      renderWithMantine(<StatsCard label="総TODO数" value={5} />)
+
+      // Assert
+      expect(screen.getByText('総TODO数')).toBeInTheDocument()
+      expect(screen.getByText('5')).toBeInTheDocument()
+    })
+
+    it('値が0の場合も正しく表示する', () => {
+      // Arrange & Act
+      renderWithMantine(<StatsCard label="完了済み" value={0} />)
+
+      // Assert
+      expect(screen.getByText('完了済み')).toBeInTheDocument()
+      expect(screen.getByText('0')).toBeInTheDocument()
+    })
+
+    it('大きな値も正しく表示する', () => {
+      // Arrange & Act
+      renderWithMantine(<StatsCard label="総TODO数" value={999} />)
+
+      // Assert
+      expect(screen.getByText('総TODO数')).toBeInTheDocument()
+      expect(screen.getByText('999')).toBeInTheDocument()
+    })
+  })
+
+  describe('カラーバリアント', () => {
+    it('primaryカラーバリアントを適用する', () => {
+      // Arrange & Act
+      renderWithMantine(<StatsCard color="blue" label="総TODO数" value={5} />)
+
+      // Assert
+      const valueElement = screen.getByText('5')
+      expect(valueElement).toHaveStyle({
+        color: 'var(--mantine-color-blue-text)',
+      })
+    })
+
+    it('successカラーバリアントを適用する', () => {
+      // Arrange & Act
+      renderWithMantine(<StatsCard color="green" label="完了済み" value={3} />)
+
+      // Assert
+      const valueElement = screen.getByText('3')
+      expect(valueElement).toHaveStyle({
+        color: 'var(--mantine-color-green-text)',
+      })
+    })
+
+    it('warningカラーバリアントを適用する', () => {
+      // Arrange & Act
+      renderWithMantine(<StatsCard color="orange" label="未完了" value={2} />)
+
+      // Assert
+      const valueElement = screen.getByText('2')
+      expect(valueElement).toHaveStyle({
+        color: 'var(--mantine-color-orange-text)',
+      })
+    })
+  })
+
+  describe('アクセシビリティ', () => {
+    it('適切なaria-labelを持つ', () => {
+      // Arrange & Act
+      renderWithMantine(<StatsCard label="総TODO数" value={5} />)
+
+      // Assert
+      expect(screen.getByLabelText('総TODO数: 5')).toBeInTheDocument()
+    })
+  })
+})

--- a/tests/components/dashboard/todo-stats-dashboard.test.tsx
+++ b/tests/components/dashboard/todo-stats-dashboard.test.tsx
@@ -1,0 +1,205 @@
+import { MantineProvider } from '@mantine/core'
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+
+import { TodoStatsDashboard } from '@/components/dashboard/todo-stats-dashboard'
+import { useTodoStats } from '@/stores/todo-store'
+
+/**
+ * MantineProviderでラップしたカスタムrender関数
+ */
+function renderWithMantine(ui: React.ReactElement) {
+  return render(<MantineProvider>{ui}</MantineProvider>)
+}
+
+// useTodoStatsフックのモック
+vi.mock('@/stores/todo-store', () => ({
+  useTodoStats: vi.fn(),
+}))
+
+const mockUseTodoStats = vi.mocked(useTodoStats)
+
+describe('TodoStatsDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('基本的な表示', () => {
+    it('統計情報を正しく表示する', () => {
+      // Arrange
+      mockUseTodoStats.mockReturnValue({
+        completed: 3,
+        completionRate: 60,
+        pending: 2,
+        total: 5,
+      })
+
+      // Act
+      renderWithMantine(<TodoStatsDashboard />)
+
+      // Assert
+      expect(screen.getByText('TODO統計')).toBeInTheDocument()
+      expect(screen.getByText('総TODO数')).toBeInTheDocument()
+      expect(screen.getByText('5')).toBeInTheDocument()
+      expect(screen.getByText('完了済み')).toBeInTheDocument()
+      expect(screen.getByText('3')).toBeInTheDocument()
+      expect(screen.getByText('未完了')).toBeInTheDocument()
+      expect(screen.getByText('2')).toBeInTheDocument()
+      expect(screen.getByText('完了率')).toBeInTheDocument()
+      expect(screen.getByText('60%')).toBeInTheDocument()
+    })
+
+    it('TODOが存在しない場合の統計を表示する', () => {
+      // Arrange
+      mockUseTodoStats.mockReturnValue({
+        completed: 0,
+        completionRate: 0,
+        pending: 0,
+        total: 0,
+      })
+
+      // Act
+      renderWithMantine(<TodoStatsDashboard />)
+
+      // Assert
+      expect(screen.getByText('TODO統計')).toBeInTheDocument()
+      expect(screen.getByText('総TODO数')).toBeInTheDocument()
+      expect(screen.getByLabelText('総TODO数: 0')).toBeInTheDocument()
+      expect(screen.getByText('完了済み')).toBeInTheDocument()
+      expect(screen.getByLabelText('完了済み: 0')).toBeInTheDocument()
+      expect(screen.getByText('未完了')).toBeInTheDocument()
+      expect(screen.getByLabelText('未完了: 0')).toBeInTheDocument()
+      expect(screen.getByText('完了率')).toBeInTheDocument()
+      expect(screen.getByText('0%')).toBeInTheDocument()
+    })
+
+    it('すべてのTODOが完了している場合の統計を表示する', () => {
+      // Arrange
+      mockUseTodoStats.mockReturnValue({
+        completed: 5,
+        completionRate: 100,
+        pending: 0,
+        total: 5,
+      })
+
+      // Act
+      renderWithMantine(<TodoStatsDashboard />)
+
+      // Assert
+      expect(screen.getByText('総TODO数')).toBeInTheDocument()
+      expect(screen.getByLabelText('総TODO数: 5')).toBeInTheDocument()
+      expect(screen.getByText('完了済み')).toBeInTheDocument()
+      expect(screen.getByLabelText('完了済み: 5')).toBeInTheDocument()
+      expect(screen.getByText('未完了')).toBeInTheDocument()
+      expect(screen.getByLabelText('未完了: 0')).toBeInTheDocument()
+      expect(screen.getByText('完了率')).toBeInTheDocument()
+      expect(screen.getByText('100%')).toBeInTheDocument()
+    })
+  })
+
+  describe('レスポンシブレイアウト', () => {
+    it('統計カードが正しくグリッドレイアウトで表示される', () => {
+      // Arrange
+      mockUseTodoStats.mockReturnValue({
+        completed: 3,
+        completionRate: 75,
+        pending: 1,
+        total: 4,
+      })
+
+      // Act
+      renderWithMantine(<TodoStatsDashboard />)
+
+      // Assert
+      // グリッドコンテナの存在確認
+      const statsContainer = screen.getByTestId('stats-cards-container')
+      expect(statsContainer).toBeInTheDocument()
+      expect(statsContainer).toHaveClass('mantine-SimpleGrid-root')
+    })
+
+    it('完了率プログレスバーが表示される', () => {
+      // Arrange
+      mockUseTodoStats.mockReturnValue({
+        completed: 3,
+        completionRate: 75,
+        pending: 1,
+        total: 4,
+      })
+
+      // Act
+      renderWithMantine(<TodoStatsDashboard />)
+
+      // Assert
+      const progressBar = screen.getByRole('progressbar')
+      expect(progressBar).toBeInTheDocument()
+      expect(progressBar).toHaveAttribute('aria-valuenow', '75')
+    })
+  })
+
+  describe('統計カードの色分け', () => {
+    it('各統計カードが適切な色で表示される', () => {
+      // Arrange
+      mockUseTodoStats.mockReturnValue({
+        completed: 3,
+        completionRate: 75,
+        pending: 2,
+        total: 5,
+      })
+
+      // Act
+      renderWithMantine(<TodoStatsDashboard />)
+
+      // Assert
+      // 総TODO数カード（青色）
+      const totalValue = screen.getByLabelText('総TODO数: 5')
+      expect(totalValue).toBeInTheDocument()
+
+      // 完了済みカード（緑色）
+      const completedValue = screen.getByLabelText('完了済み: 3')
+      expect(completedValue).toBeInTheDocument()
+
+      // 未完了カード（オレンジ色）
+      const pendingValue = screen.getByLabelText('未完了: 2')
+      expect(pendingValue).toBeInTheDocument()
+    })
+  })
+
+  describe('アクセシビリティ', () => {
+    it('適切な見出し構造を持つ', () => {
+      // Arrange
+      mockUseTodoStats.mockReturnValue({
+        completed: 3,
+        completionRate: 75,
+        pending: 2,
+        total: 5,
+      })
+
+      // Act
+      renderWithMantine(<TodoStatsDashboard />)
+
+      // Assert
+      const heading = screen.getByRole('heading', { name: 'TODO統計' })
+      expect(heading).toBeInTheDocument()
+      expect(heading.tagName).toBe('H2')
+    })
+
+    it('統計情報がセクションとして認識される', () => {
+      // Arrange
+      mockUseTodoStats.mockReturnValue({
+        completed: 3,
+        completionRate: 75,
+        pending: 2,
+        total: 5,
+      })
+
+      // Act
+      renderWithMantine(<TodoStatsDashboard />)
+
+      // Assert
+      const section = screen.getByRole('region', {
+        name: 'TODO統計ダッシュボード',
+      })
+      expect(section).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## 📝 概要

TODO項目の統計情報を視覚的に表示するダッシュボード機能を実装しました。ユーザーは総TODO数、完了数、未完了数、完了率を一目で確認できます。

## 🎯 変更内容

- [x] 機能: TODO統計ダッシュボード
- [ ] バグ修正:
- [ ] リファクタリング:
- [ ] ドキュメント更新:

## 🔧 技術的な変更点

- 統計表示用のStatsCardコンポーネント実装
- 完了率プログレスバー用のCompletionProgressコンポーネント実装
- メインダッシュボードコンポーネント（TodoStatsDashboard）実装
- 既存のuseTodoStatsフックを活用して統計情報を取得
- メインページにダッシュボードを統合
- TDDアプローチで包括的なテスト実装
- レスポンシブデザイン対応（Mantineのグリッドシステム使用）
- アクセシビリティ配慮（適切なaria-label、role属性）
- 完了率に応じた色分け（赤・黄・緑）

## ✅ テスト

- [x] 単体テストを追加/更新（23個のテスト追加）
- [x] 統合テストを実行（全131テスト通過）
- [x] 手動での動作確認完了
- [x] TDDでテストファースト開発

## ⚠️ 破壊的変更

- なし

## 🔗 関連Issue

- ユーザーリクエスト: TODOの統計情報表示機能

## 📋 レビュー観点

1. ダッシュボードの表示内容とUIデザイン
2. テストカバレッジの妥当性
3. アクセシビリティ対応の適切性
4. パフォーマンスへの影響

## 📚 参考資料

- Mantine UIライブラリ Documentation
- React Testing Library Best Practices

🤖 Generated with [Claude Code](https://claude.ai/code)