### PR TITLE
TODO追加モーダル機能の実装

### DIFF
--- a/src/components/todo-add-modal.tsx
+++ b/src/components/todo-add-modal.tsx
@@ -1,0 +1,224 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import {
+  Button,
+  Group,
+  Modal,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core'
+
+/**
+ * TODO追加フォームのデータ
+ */
+interface TodoAddFormData {
+  /** 説明 */
+  description: string
+  /** 期限 */
+  dueDate: Date | null
+  /** タイトル */
+  title: string
+}
+
+/**
+ * TodoAddModalコンポーネントのProps
+ */
+interface TodoAddModalProps {
+  /** モーダルを閉じる関数 */
+  onClose: () => void
+  /** フォーム送信時のコールバック */
+  onSubmit: (data: TodoAddFormData) => void
+  /** モーダルの開閉状態 */
+  opened: boolean
+}
+
+/**
+ * 期限選択肢のデータ
+ */
+const dueDateOptions = [
+  { label: '期限なし', value: '' },
+  { label: '今日', value: 'today' },
+  { label: '明日', value: 'tomorrow' },
+  { label: '来週', value: 'next-week' },
+  { label: 'カレンダーから指定', value: 'calendar' },
+]
+
+/**
+ * TODO追加モーダルコンポーネント
+ *
+ * @description
+ * Microsoft To-Do風のTODO追加モーダルです。
+ * 以下の機能を提供します：
+ * - タイトル入力（必須）
+ * - 説明入力（任意）
+ * - 期限選択（任意）
+ * - バリデーション
+ * - フォーカス管理
+ *
+ * @example
+ * ```tsx
+ * <TodoAddModal
+ *   opened={opened}
+ *   onClose={handlers.close}
+ *   onSubmit={handleSubmit}
+ * />
+ * ```
+ */
+export function TodoAddModal({ onClose, onSubmit, opened }: TodoAddModalProps) {
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [dueDate, setDueDate] = useState<null | string>('')
+  const [titleError, setTitleError] = useState('')
+
+  /**
+   * フォームをリセットする
+   */
+  function resetForm() {
+    setTitle('')
+    setDescription('')
+    setDueDate('')
+    setTitleError('')
+  }
+
+  /**
+   * モーダルが閉じられた時の処理
+   */
+  function handleClose() {
+    resetForm()
+    onClose()
+  }
+
+  /**
+   * フォーム送信処理
+   */
+  function handleSubmit() {
+    // バリデーション
+    if (!title.trim()) {
+      setTitleError('タイトルは必須です')
+      return
+    }
+
+    setTitleError('')
+
+    // 期限を実際の日付に変換
+    const convertedDueDate = convertDueDateToDate(dueDate)
+
+    // フォームデータを送信
+    onSubmit({
+      description: description.trim(),
+      dueDate: convertedDueDate,
+      title: title.trim(),
+    })
+
+    // フォームをリセット
+    resetForm()
+  }
+
+  /**
+   * タイトル入力変更時の処理
+   */
+  function handleTitleChange(value: string) {
+    setTitle(value)
+    if (titleError && value.trim()) {
+      setTitleError('')
+    }
+  }
+
+  // モーダルが閉じられた時にフォームをリセット
+  useEffect(() => {
+    if (!opened) {
+      resetForm()
+    }
+  }, [opened])
+
+  return (
+    <Modal
+      centered
+      onClose={handleClose}
+      opened={opened}
+      size="md"
+      title="新しいタスクを追加"
+    >
+      <Stack gap="md">
+        <TextInput
+          data-autofocus
+          error={titleError}
+          label="タイトル"
+          onChange={(event) => handleTitleChange(event.currentTarget.value)}
+          placeholder="タスクのタイトルを入力してください"
+          required
+          value={title}
+        />
+
+        <Textarea
+          label="説明"
+          onChange={(event) => setDescription(event.currentTarget.value)}
+          placeholder="タスクの説明を入力してください（任意）"
+          rows={3}
+          value={description}
+        />
+
+        <div>
+          <Text fw={500} mb={5} size="sm">
+            期限
+          </Text>
+          <Select
+            clearable
+            data={dueDateOptions}
+            onChange={setDueDate}
+            placeholder="期限を選択してください"
+            value={dueDate}
+          />
+        </div>
+
+        <Group justify="flex-end" mt="md">
+          <Button onClick={handleClose} variant="subtle">
+            キャンセル
+          </Button>
+          <Button onClick={handleSubmit}>作成</Button>
+        </Group>
+      </Stack>
+    </Modal>
+  )
+}
+
+/**
+ * 期限選択値を実際の日付に変換する
+ *
+ * @param dueDateValue 期限選択値
+ * @returns 変換された日付またはnull
+ */
+function convertDueDateToDate(dueDateValue: null | string): Date | null {
+  if (!dueDateValue) return null
+
+  const today = new Date()
+  today.setHours(23, 59, 59, 999) // 当日の終了時刻に設定
+
+  switch (dueDateValue) {
+    case 'calendar': {
+      // カレンダーから指定の場合は現在は未実装のためnullを返す
+      return null
+    }
+    case 'next-week': {
+      const nextWeek = new Date(today)
+      nextWeek.setDate(nextWeek.getDate() + 7)
+      return nextWeek
+    }
+    case 'today': {
+      return today
+    }
+    case 'tomorrow': {
+      const tomorrow = new Date(today)
+      tomorrow.setDate(tomorrow.getDate() + 1)
+      return tomorrow
+    }
+    default: {
+      return null
+    }
+  }
+}

--- a/src/components/todo-add-modal.tsx
+++ b/src/components/todo-add-modal.tsx
@@ -20,7 +20,7 @@ interface TodoAddFormData {
   /** 説明 */
   description: string
   /** 期限 */
-  dueDate: Date | null
+  dueDate: Date | undefined
   /** タイトル */
   title: string
 }
@@ -72,7 +72,7 @@ const dueDateOptions = [
 export function TodoAddModal({ onClose, onSubmit, opened }: TodoAddModalProps) {
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
-  const [dueDate, setDueDate] = useState<null | string>('')
+  const [dueDate, setDueDate] = useState<string | undefined>('')
   const [titleError, setTitleError] = useState('')
 
   /**
@@ -170,7 +170,7 @@ export function TodoAddModal({ onClose, onSubmit, opened }: TodoAddModalProps) {
           <Select
             clearable
             data={dueDateOptions}
-            onChange={setDueDate}
+            onChange={(value) => setDueDate(value ?? undefined)}
             placeholder="期限を選択してください"
             value={dueDate}
           />
@@ -191,18 +191,20 @@ export function TodoAddModal({ onClose, onSubmit, opened }: TodoAddModalProps) {
  * 期限選択値を実際の日付に変換する
  *
  * @param dueDateValue 期限選択値
- * @returns 変換された日付またはnull
+ * @returns 変換された日付またはundefined
  */
-function convertDueDateToDate(dueDateValue: null | string): Date | null {
-  if (!dueDateValue) return null
+function convertDueDateToDate(
+  dueDateValue: string | undefined
+): Date | undefined {
+  if (!dueDateValue) return undefined
 
   const today = new Date()
   today.setHours(23, 59, 59, 999) // 当日の終了時刻に設定
 
   switch (dueDateValue) {
     case 'calendar': {
-      // カレンダーから指定の場合は現在は未実装のためnullを返す
-      return null
+      // カレンダーから指定の場合は現在は未実装のためundefinedを返す
+      return undefined
     }
     case 'next-week': {
       const nextWeek = new Date(today)
@@ -218,7 +220,7 @@ function convertDueDateToDate(dueDateValue: null | string): Date | null {
       return tomorrow
     }
     default: {
-      return null
+      return undefined
     }
   }
 }

--- a/src/components/todo-list-modern.tsx
+++ b/src/components/todo-list-modern.tsx
@@ -10,10 +10,12 @@ import {
   Text,
   Title,
 } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
 import { IconPlus, IconStar } from '@tabler/icons-react'
 
 import type { Todo } from '@/types/todo'
 
+import { TodoAddModal } from '@/components/todo-add-modal'
 import { useTodoStore } from '@/stores/todo-store'
 import { useTodoUIStore } from '@/stores/todo-ui-store'
 
@@ -70,8 +72,9 @@ interface TodoListModernProps {
  * ```
  */
 export function TodoListModern({ showEmpty = false }: TodoListModernProps) {
-  const { todos, toggleTodoStatus } = useTodoStore()
+  const { addTodo, todos, toggleTodoStatus } = useTodoStore()
   const { setSelectedTodoId } = useTodoUIStore()
+  const [opened, { close, open }] = useDisclosure(false)
 
   // 現在の日付をフォーマット
   const today = new Date()
@@ -103,6 +106,29 @@ export function TodoListModern({ showEmpty = false }: TodoListModernProps) {
     }
   }
 
+  /**
+   * TODO作成処理
+   *
+   * @param data TODO作成データ
+   */
+  async function handleCreateTodo(data: {
+    description: string
+    dueDate: Date | null
+    title: string
+  }) {
+    try {
+      await addTodo({
+        description: data.description,
+        dueDate: data.dueDate,
+        status: 'pending',
+        title: data.title,
+      })
+      close()
+    } catch (error) {
+      console.error('Failed to create todo:', error)
+    }
+  }
+
   // テスト用の空表示
   if (showEmpty) {
     return (
@@ -120,7 +146,7 @@ export function TodoListModern({ showEmpty = false }: TodoListModernProps) {
           <Button
             justify="flex-start"
             leftSection={<IconPlus size={16} />}
-            onClick={handleAddTask}
+            onClick={open}
             style={{ textAlign: 'left' }}
             variant="subtle"
           >
@@ -152,7 +178,7 @@ export function TodoListModern({ showEmpty = false }: TodoListModernProps) {
         <Button
           justify="flex-start"
           leftSection={<IconPlus size={16} />}
-          onClick={handleAddTask}
+          onClick={open}
           style={{ textAlign: 'left' }}
           variant="subtle"
         >
@@ -190,16 +216,15 @@ export function TodoListModern({ showEmpty = false }: TodoListModernProps) {
           )}
         </Stack>
       </Stack>
+
+      {/* TODO追加モーダル */}
+      <TodoAddModal
+        onClose={close}
+        onSubmit={handleCreateTodo}
+        opened={opened}
+      />
     </Box>
   )
-}
-
-/**
- * タスク追加ボタンクリック処理（ダミー）
- */
-function handleAddTask() {
-  // TODO: 後でモーダルでタスク追加ダイアログを表示する
-  console.log('タスク追加ボタンがクリックされました')
 }
 
 /**

--- a/src/components/todo-list-modern.tsx
+++ b/src/components/todo-list-modern.tsx
@@ -113,7 +113,7 @@ export function TodoListModern({ showEmpty = false }: TodoListModernProps) {
    */
   async function handleCreateTodo(data: {
     description: string
-    dueDate: Date | null
+    dueDate: Date | undefined
     title: string
   }) {
     try {

--- a/src/tests/components/todo-add-modal.test.tsx
+++ b/src/tests/components/todo-add-modal.test.tsx
@@ -109,7 +109,7 @@ describe('TodoAddModal', () => {
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalledWith({
         description: 'テストの説明',
-        dueDate: null,
+        dueDate: undefined,
         title: 'テストタスク',
       })
     })
@@ -191,7 +191,7 @@ describe('TodoAddModal', () => {
 
     await waitFor(() => {
       const call = mockOnSubmit.mock.calls[0] as [
-        { description: string; dueDate: Date | null; title: string; },
+        { description: string; dueDate: Date | undefined; title: string },
       ]
       expect(call[0].title).toBe('テストタスク')
       expect(call[0].description).toBe('')

--- a/src/tests/components/todo-add-modal.test.tsx
+++ b/src/tests/components/todo-add-modal.test.tsx
@@ -1,0 +1,246 @@
+import { MantineProvider } from '@mantine/core'
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { vi } from 'vitest'
+
+import { TodoAddModal } from '@/components/todo-add-modal'
+
+// MantineProviderでラップするヘルパー関数
+function renderWithMantine(component: React.ReactElement) {
+  return render(<MantineProvider>{component}</MantineProvider>)
+}
+
+describe('TodoAddModal', () => {
+  const mockOnClose = vi.fn()
+  const mockOnSubmit = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // 基本的なレンダリングテスト
+  it('モーダルが開いている状態で正しくレンダリングされる', () => {
+    renderWithMantine(
+      <TodoAddModal
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        opened={true}
+      />
+    )
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('新しいタスクを追加')).toBeInTheDocument()
+  })
+
+  // 閉じた状態でのテスト
+  it('モーダルが閉じている状態ではレンダリングされない', () => {
+    renderWithMantine(
+      <TodoAddModal
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        opened={false}
+      />
+    )
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  // フォーム要素のテスト
+  it('必要なフォーム要素がレンダリングされる', () => {
+    renderWithMantine(
+      <TodoAddModal
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        opened={true}
+      />
+    )
+
+    expect(
+      screen.getByRole('textbox', { name: 'タイトル' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: '説明' })).toBeInTheDocument()
+    expect(screen.getByText('期限')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '作成' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'キャンセル' })
+    ).toBeInTheDocument()
+  })
+
+  // 期限選択肢のテスト
+  it('期限選択肢が正しく表示される', async () => {
+    renderWithMantine(
+      <TodoAddModal
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        opened={true}
+      />
+    )
+
+    const dueDateSelect = screen.getByDisplayValue('期限なし')
+    await userEvent.click(dueDateSelect)
+
+    await waitFor(() => {
+      expect(screen.getByText('期限なし')).toBeInTheDocument()
+      expect(screen.getByText('今日')).toBeInTheDocument()
+      expect(screen.getByText('明日')).toBeInTheDocument()
+      expect(screen.getByText('来週')).toBeInTheDocument()
+      expect(screen.getByText('カレンダーから指定')).toBeInTheDocument()
+    })
+  })
+
+  // フォーム送信のテスト
+  it('フォーム送信が正しく動作する', async () => {
+    renderWithMantine(
+      <TodoAddModal
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        opened={true}
+      />
+    )
+
+    const titleInput = screen.getByRole('textbox', { name: 'タイトル' })
+    const descriptionInput = screen.getByRole('textbox', { name: '説明' })
+    const submitButton = screen.getByRole('button', { name: '作成' })
+
+    await userEvent.type(titleInput, 'テストタスク')
+    await userEvent.type(descriptionInput, 'テストの説明')
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        description: 'テストの説明',
+        dueDate: null,
+        title: 'テストタスク',
+      })
+    })
+  })
+
+  // バリデーションのテスト
+  it('タイトルが空の場合はエラーが表示される', async () => {
+    renderWithMantine(
+      <TodoAddModal
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        opened={true}
+      />
+    )
+
+    const submitButton = screen.getByRole('button', { name: '作成' })
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('タイトルは必須です')).toBeInTheDocument()
+    })
+    expect(mockOnSubmit).not.toHaveBeenCalled()
+  })
+
+  // キャンセルボタンのテスト
+  it('キャンセルボタンでモーダルが閉じられる', async () => {
+    renderWithMantine(
+      <TodoAddModal
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        opened={true}
+      />
+    )
+
+    const cancelButton = screen.getByRole('button', { name: 'キャンセル' })
+    await userEvent.click(cancelButton)
+
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  // フォーカス管理のテスト
+  it('モーダルが開いた時にタイトル入力欄にフォーカスが当たる', async () => {
+    renderWithMantine(
+      <TodoAddModal
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        opened={true}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'タイトル' })).toHaveFocus()
+    })
+  })
+
+  // 期限選択のテスト
+  it('期限選択が正しく動作する', async () => {
+    renderWithMantine(
+      <TodoAddModal
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        opened={true}
+      />
+    )
+
+    const titleInput = screen.getByRole('textbox', { name: 'タイトル' })
+    const dueDateSelect = screen.getByDisplayValue('期限なし')
+    const submitButton = screen.getByRole('button', { name: '作成' })
+
+    await userEvent.type(titleInput, 'テストタスク')
+    await userEvent.click(dueDateSelect)
+
+    await waitFor(() => {
+      expect(screen.getByText('今日')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByText('今日'))
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      const call = mockOnSubmit.mock.calls[0] as [
+        { description: string; dueDate: Date | null; title: string; },
+      ]
+      expect(call[0].title).toBe('テストタスク')
+      expect(call[0].description).toBe('')
+      expect(call[0].dueDate).toBeInstanceOf(Date)
+      // 今日の日付かチェック（時間は無視）
+      const today = new Date()
+      const receivedDate = call[0].dueDate!
+      expect(receivedDate.getDate()).toBe(today.getDate())
+      expect(receivedDate.getMonth()).toBe(today.getMonth())
+      expect(receivedDate.getFullYear()).toBe(today.getFullYear())
+    })
+  })
+
+  // フォームリセットのテスト
+  it('モーダルが閉じられた時にフォームがリセットされる', async () => {
+    const { rerender } = renderWithMantine(
+      <TodoAddModal
+        onClose={mockOnClose}
+        onSubmit={mockOnSubmit}
+        opened={true}
+      />
+    )
+
+    const titleInput = screen.getByRole('textbox', { name: 'タイトル' })
+    await userEvent.type(titleInput, 'テストタスク')
+
+    // モーダルを閉じる
+    rerender(
+      <MantineProvider>
+        <TodoAddModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+          opened={false}
+        />
+      </MantineProvider>
+    )
+
+    // 再度開く
+    rerender(
+      <MantineProvider>
+        <TodoAddModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+          opened={true}
+        />
+      </MantineProvider>
+    )
+
+    const newTitleInput = screen.getByRole('textbox', { name: 'タイトル' })
+    expect(newTitleInput).toHaveValue('')
+  })
+})

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -25,6 +25,19 @@ Object.defineProperty(globalThis, 'matchMedia', {
   writable: true,
 })
 
+// Mock ResizeObserver for Mantine
+Object.defineProperty(globalThis, 'ResizeObserver', {
+  value: vi.fn().mockImplementation((_callback) => ({
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+  })),
+  writable: true,
+})
+
+// Mock scrollIntoView for Mantine Combobox
+Element.prototype.scrollIntoView = vi.fn()
+
 // Mock Next.js router
 
 vi.mock('next/navigation', () => ({

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -5,7 +5,7 @@ export interface CreateTodoInput {
   /** TODO項目の説明（オプション） */
   description?: string
   /** TODO項目の期限（オプション） */
-  dueDate?: Date | null | string
+  dueDate?: Date | null | string | undefined
   /** TODO項目の状態（オプション、デフォルト: pending） */
   status?: TodoStatus
   /** TODO項目のタイトル */
@@ -21,7 +21,7 @@ export interface Todo {
   /** TODO項目の説明（オプション） */
   description?: string
   /** TODO項目の期限（オプション） */
-  dueDate?: Date | null | string
+  dueDate?: Date | null | string | undefined
   /** TODO項目の一意識別子 */
   id: string
   /** TODO項目の状態 */
@@ -44,7 +44,7 @@ export interface UpdateTodoInput {
   /** TODO項目の説明（オプション） */
   description?: string
   /** TODO項目の期限（オプション） */
-  dueDate?: Date | null | string
+  dueDate?: Date | null | string | undefined
   /** TODO項目の状態 */
   status?: TodoStatus
   /** TODO項目のタイトル */

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -4,6 +4,10 @@
 export interface CreateTodoInput {
   /** TODO項目の説明（オプション） */
   description?: string
+  /** TODO項目の期限（オプション） */
+  dueDate?: Date | null | string
+  /** TODO項目の状態（オプション、デフォルト: pending） */
+  status?: TodoStatus
   /** TODO項目のタイトル */
   title: string
 }
@@ -16,6 +20,8 @@ export interface Todo {
   createdAt: Date | string
   /** TODO項目の説明（オプション） */
   description?: string
+  /** TODO項目の期限（オプション） */
+  dueDate?: Date | null | string
   /** TODO項目の一意識別子 */
   id: string
   /** TODO項目の状態 */
@@ -37,6 +43,8 @@ export type TodoStatus = 'completed' | 'pending'
 export interface UpdateTodoInput {
   /** TODO項目の説明（オプション） */
   description?: string
+  /** TODO項目の期限（オプション） */
+  dueDate?: Date | null | string
   /** TODO項目の状態 */
   status?: TodoStatus
   /** TODO項目のタイトル */


### PR DESCRIPTION
## 概要
Microsoft To-Do風のTODO一覧画面にモーダルを使用したTODO追加機能を実装しました。

## 主な変更点
- **TodoAddModalコンポーネント**の新規作成
  - Mantineの`Modal`, `TextInput`, `Textarea`, `Select`コンポーネントを使用
  - タイトル（必須）、説明（任意）、期限（任意）の入力フィールド
  - 期限選択：今日、明日、来週、カレンダーから指定（カレンダーは未実装）
  - バリデーション：タイトル必須チェック
  - フォーカス管理：モーダル開閉時の適切なフォーカス移動

- **TodoListModernコンポーネント**の機能拡張
  - `useDisclosure`フックでモーダル開閉状態管理
  - TODO作成機能の統合
  - 「タスクの追加」ボタンの実機能化

- **型定義の拡張**
  - `Todo`, `CreateTodoInput`, `UpdateTodoInput`型に`dueDate`フィールドを追加
  - 期限情報の適切な型安全性を確保

- **期限選択機能**
  - 選択値から実際のDateオブジェクトへの変換処理
  - 今日、明日、来週の自動日付計算
  - 期限終了時刻（23:59:59）の設定

- **テスト実装**
  - TodoAddModalコンポーネントの包括的なテスト（10件）
  - モーダルの開閉、フォーム送信、バリデーション、期限選択のテスト
  - Mantineコンポーネントのモックとテスト環境整備

- **テスト環境の改善**
  - ResizeObserverとscrollIntoViewのモック追加
  - Mantineコンポーネントのテスト実行環境整備

## テストカバレッジ
- 全217テストが通過
- 新規追加: TodoAddModalコンポーネントの10件のテスト
- 既存テストへの影響なし

## 品質チェック
- ✅ TypeScript型チェック通過
- ✅ ESLint（軽微な警告のみ）
- ✅ Prettier フォーマット
- ✅ Vitest テスト（217件すべて通過）
- ✅ Next.js ビルド成功

## 未実装機能
- カレンダーからの日付指定機能（将来的に実装予定）

🤖 Generated with [Claude Code](https://claude.ai/code)