### PR TITLE
fix: カテゴリID検証エラーの修正 - UUID形式からCUID形式への変更

### DIFF
--- a/src/schemas/todo.ts
+++ b/src/schemas/todo.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
  */
 export const todoSchema = z.object({
   categoryId: z
-    .union([z.string().uuid(), z.literal(''), z.null()])
+    .union([z.string().cuid(), z.literal(''), z.null()])
     .optional()
     .transform((val) => (val === '' || val === null ? undefined : val)),
   description: z
@@ -26,7 +26,7 @@ export const todoSchema = z.object({
 export const todoUpdateSchema = todoSchema.partial()
 
 export const todoQuerySchema = z.object({
-  categoryId: z.string().uuid().optional(),
+  categoryId: z.string().cuid().optional(),
   filter: z
     .enum(['today', 'important', 'upcoming', 'completed', 'all'])
     .default('all'),


### PR DESCRIPTION
## 概要
TODOのカテゴリを変更する際に発生していたHTTP 400エラーを修正しました。

## 問題
- カテゴリIDの値がPrismaが生成するCUID形式（例: `cmct1abg90001oddbn5yodzk7`）であるのに対し、ZodバリデーションスキーマはUUID形式を期待していました
- これにより、カテゴリ変更時に「Invalid uuid」というバリデーションエラーが発生していました

## 解決方法
- `src/schemas/todo.ts`のバリデーションスキーマを修正
- `z.string().uuid()` → `z.string().cuid()`に変更
- `todoSchema`と`todoQuerySchema`の両方で修正を適用

## テスト結果
- ✅ 全303件のテストが正常に通過
- ✅ TypeScriptの型チェック成功
- ✅ ESLintチェック成功

## 動作確認
カテゴリ変更時のHTTP 400エラーが解消され、正常に動作することを確認してください。

🤖 Generated with [Claude Code](https://claude.ai/code)