### PR TITLE
feat: 日付選択カレンダーを日曜日始まりに変更

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 import { ColorSchemeScript, MantineProvider } from '@mantine/core'
+import { DatesProvider } from '@mantine/dates'
 
 import type { Metadata } from 'next'
 
@@ -36,7 +37,9 @@ export default function RootLayout({
       </head>
       <body>
         <MantineProvider>
-          <AppProvider>{children}</AppProvider>
+          <DatesProvider settings={{ firstDayOfWeek: 0, locale: 'ja' }}>
+            <AppProvider>{children}</AppProvider>
+          </DatesProvider>
         </MantineProvider>
       </body>
     </html>

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -17,7 +17,9 @@ import '@mantine/dates/styles.css'
 function AllTheProviders({ children }: { children: React.ReactNode }) {
   return (
     <MantineProvider>
-      <DatesProvider settings={{ locale: 'ja' }}>{children}</DatesProvider>
+      <DatesProvider settings={{ firstDayOfWeek: 0, locale: 'ja' }}>
+        {children}
+      </DatesProvider>
     </MantineProvider>
   )
 }


### PR DESCRIPTION
## 概要
日付選択カレンダーの週の開始日を日曜日に変更しました。

## 変更内容
- MantineのDatesProviderを追加し、`firstDayOfWeek: 0`を設定
- アプリケーション全体の日付選択UIが日曜日始まりのカレンダーを表示するよう統一
- テスト環境でも同様の設定を適用し、一貫性を確保

## 技術的詳細
- `DatesProvider`で`firstDayOfWeek: 0`を設定（0 = 日曜日）
- 日本語ロケール（`locale: 'ja'`）も同時に設定
- すべての`DatePickerInput`コンポーネントに自動的に適用

## テスト計画
- [x] 日付選択UIで日曜日が最初の曜日として表示されることを確認
- [x] すべてのテストが正常に通過
- [x] 型チェックが成功
- [x] リントエラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)