### PR TITLE
fix: 日付バリデーションでYYYY-MM-DD形式を受け入れるように修正

### DIFF
--- a/.claude/commands/fix.md
+++ b/.claude/commands/fix.md
@@ -1,0 +1,16 @@
+# Fix the error described in below
+
+## Error
+
+- $ARGUMENTS
+
+## Task
+
+1. Checkout the branch named `fix/<branch name>`
+2. Plan the fix
+3. Show fixing plan to user
+4. When user approve, do the task
+5. Do `yarn format`, `yarn lint`, `yarn typecheck`, `yarn test`
+6. Commit the changes if all checks in 5. are passed.
+7. Push to the remote
+8. Create PR

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -246,11 +246,14 @@ async function main() {
   console.log('シーディング完了！')
 }
 
-try {
-  await main()
-} catch (error) {
-  console.error('シーディングエラー:', error)
-  throw error
-} finally {
-  await prisma.$disconnect()
-}
+main()
+  .then(async () => {
+    await prisma.$disconnect()
+  })
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  .catch(async (error) => {
+    console.error(error)
+    await prisma.$disconnect()
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1)
+  })

--- a/src/app/api/todos/[id]/route.ts
+++ b/src/app/api/todos/[id]/route.ts
@@ -171,6 +171,16 @@ export async function PUT(
       return createValidationErrorResponse(error.errors)
     }
 
+    if (error instanceof TypeError && error.message.includes('Invalid date')) {
+      return createValidationErrorResponse([
+        {
+          code: 'invalid_date',
+          message: 'Invalid date format',
+          path: ['dueDate'],
+        },
+      ])
+    }
+
     if (error instanceof Error && error.message === '認証が必要です') {
       return createErrorResponse('UNAUTHORIZED', '認証が必要です', 401)
     }

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -101,9 +101,7 @@ export async function POST(request: NextRequest) {
     const todo = await prisma.todo.create({
       data: {
         ...validatedData,
-        dueDate: validatedData.dueDate
-          ? new Date(validatedData.dueDate)
-          : undefined,
+        dueDate: validatedData.dueDate ?? undefined,
         userId,
       },
       include: {
@@ -121,6 +119,16 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     if (error instanceof z.ZodError) {
       return createValidationErrorResponse(error.errors)
+    }
+
+    if (error instanceof TypeError && error.message.includes('Invalid date')) {
+      return createValidationErrorResponse([
+        {
+          code: 'invalid_date',
+          message: 'Invalid date format',
+          path: ['dueDate'],
+        },
+      ])
     }
 
     if (error instanceof Error && error.message === '認証が必要です') {

--- a/src/schemas/todo.test.ts
+++ b/src/schemas/todo.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest'
+
+import { todoSchema } from './todo'
+
+describe('todoSchema', () => {
+  describe('dueDate validation', () => {
+    it('accepts valid date string in YYYY-MM-DD format', () => {
+      // Arrange
+      const validTodo = {
+        description: 'Test description',
+        dueDate: '2025-07-09',
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.dueDate).toBeInstanceOf(Date)
+      expect(result.dueDate).toEqual(new Date('2025-07-09'))
+    })
+
+    it('accepts valid ISO datetime string', () => {
+      // Arrange
+      const validTodo = {
+        description: 'Test description',
+        dueDate: '2025-07-09T10:30:00.000Z',
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.dueDate).toBeInstanceOf(Date)
+      expect(result.dueDate).toEqual(new Date('2025-07-09T10:30:00.000Z'))
+    })
+
+    it('accepts null as dueDate', () => {
+      // Arrange
+      const validTodo = {
+        description: 'Test description',
+        dueDate: null,
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.dueDate).toBeUndefined()
+    })
+
+    it('accepts undefined as dueDate', () => {
+      // Arrange
+      const validTodo = {
+        description: 'Test description',
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.dueDate).toBeUndefined()
+    })
+
+    it('rejects invalid date string', () => {
+      // Arrange
+      const invalidTodo = {
+        description: 'Test description',
+        dueDate: 'invalid-date',
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act & Assert
+      expect(() => todoSchema.parse(invalidTodo)).toThrow()
+    })
+  })
+
+  describe('title validation', () => {
+    it('accepts valid title', () => {
+      // Arrange
+      const validTodo = {
+        isImportant: false,
+        title: 'Valid Title',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.title).toBe('Valid Title')
+    })
+
+    it('rejects empty title', () => {
+      // Arrange
+      const invalidTodo = {
+        isImportant: false,
+        title: '',
+      }
+
+      // Act & Assert
+      expect(() => todoSchema.parse(invalidTodo)).toThrow()
+    })
+
+    it('rejects title longer than 200 characters', () => {
+      // Arrange
+      const longTitle = 'a'.repeat(201)
+      const invalidTodo = {
+        isImportant: false,
+        title: longTitle,
+      }
+
+      // Act & Assert
+      expect(() => todoSchema.parse(invalidTodo)).toThrow()
+    })
+  })
+
+  describe('description validation', () => {
+    it('accepts valid description', () => {
+      // Arrange
+      const validTodo = {
+        description: 'Valid description',
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.description).toBe('Valid description')
+    })
+
+    it('accepts empty description', () => {
+      // Arrange
+      const validTodo = {
+        description: '',
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.description).toBe('')
+    })
+
+    it('rejects description longer than 1000 characters', () => {
+      // Arrange
+      const longDescription = 'a'.repeat(1001)
+      const invalidTodo = {
+        description: longDescription,
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act & Assert
+      expect(() => todoSchema.parse(invalidTodo)).toThrow()
+    })
+  })
+
+  describe('isImportant validation', () => {
+    it('accepts true value', () => {
+      // Arrange
+      const validTodo = {
+        isImportant: true,
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.isImportant).toBe(true)
+    })
+
+    it('accepts false value', () => {
+      // Arrange
+      const validTodo = {
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.isImportant).toBe(false)
+    })
+
+    it('defaults to false when not provided', () => {
+      // Arrange
+      const validTodo = {
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.isImportant).toBe(false)
+    })
+  })
+
+  describe('categoryId validation', () => {
+    it('accepts valid CUID', () => {
+      // Arrange
+      const validTodo = {
+        categoryId: 'clh7k8j9c0000xyz123456789',
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.categoryId).toBe('clh7k8j9c0000xyz123456789')
+    })
+
+    it('converts empty string to undefined', () => {
+      // Arrange
+      const validTodo = {
+        categoryId: '',
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.categoryId).toBeUndefined()
+    })
+
+    it('converts null to undefined', () => {
+      // Arrange
+      const validTodo = {
+        categoryId: null,
+        isImportant: false,
+        title: 'Test Task',
+      }
+
+      // Act
+      const result = todoSchema.parse(validTodo)
+
+      // Assert
+      expect(result.categoryId).toBeUndefined()
+    })
+  })
+})

--- a/src/schemas/todo.ts
+++ b/src/schemas/todo.ts
@@ -13,9 +13,21 @@ export const todoSchema = z.object({
     .max(1000, '説明は1000文字以内で入力してください')
     .optional(),
   dueDate: z
-    .union([z.string().datetime(), z.null()])
+    .union([z.string(), z.null(), z.undefined()])
     .optional()
-    .transform((val) => (val === null ? undefined : val)),
+    .transform((val) => {
+      if (val === null || val === undefined) return
+      if (typeof val === 'string' && val.trim() === '') return
+      try {
+        const date = new Date(val)
+        if (Number.isNaN(date.getTime())) {
+          throw new TypeError('Invalid date')
+        }
+        return date
+      } catch {
+        throw new TypeError('Invalid date format')
+      }
+    }),
   isImportant: z.boolean().default(false),
   title: z
     .string()


### PR DESCRIPTION
## Summary
- 日付バリデーションエラーを修正し、YYYY-MM-DD形式の日付を受け入れるようにしました
- Zodの`z.string().datetime()`をより柔軟な日付バリデーションに変更
- 不正な日付形式の場合は適切なバリデーションエラーを返却するよう改善

## Changes
- `src/schemas/todo.ts`: dueDateバリデーションを改善し、様々な日付形式を受け入れ
- `src/app/api/todos/route.ts`: 日付関連のTypeErrorを適切にキャッチ
- `src/app/api/todos/[id]/route.ts`: 日付関連のTypeErrorを適切にキャッチ
- `src/schemas/todo.test.ts`: 包括的なテストケースを追加

## Test plan
- [x] 既存のテストが全て通ることを確認
- [x] 新しいテストケースで日付バリデーションの動作を確認
- [x] lint、typecheck、formatが正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)