### PR TITLE
feat: TODOの削除確認をMantineダイアログに変更

### DIFF
--- a/src/app/api/stats/todos/route.test.ts
+++ b/src/app/api/stats/todos/route.test.ts
@@ -28,6 +28,15 @@ describe('/api/stats/todos', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    // console.errorをモック化
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      // エラーログを無視
+    })
+  })
+
+  afterEach(() => {
+    // モックのリストア
+    vi.restoreAllMocks()
   })
 
   it('認証されていないユーザーは401エラーを返す', async () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 
 import { ColorSchemeScript, MantineProvider } from '@mantine/core'
 import { DatesProvider } from '@mantine/dates'
+import { ModalsProvider } from '@mantine/modals'
 
 import type { Metadata } from 'next'
 
@@ -37,9 +38,16 @@ export default function RootLayout({
       </head>
       <body>
         <MantineProvider>
-          <DatesProvider settings={{ firstDayOfWeek: 0, locale: 'ja' }}>
-            <AppProvider>{children}</AppProvider>
-          </DatesProvider>
+          <ModalsProvider
+            labels={{
+              cancel: 'キャンセル',
+              confirm: '削除',
+            }}
+          >
+            <DatesProvider settings={{ firstDayOfWeek: 0, locale: 'ja' }}>
+              <AppProvider>{children}</AppProvider>
+            </DatesProvider>
+          </ModalsProvider>
         </MantineProvider>
       </body>
     </html>

--- a/src/components/category/category-list.tsx
+++ b/src/components/category/category-list.tsx
@@ -12,6 +12,7 @@ import {
   TextInput,
 } from '@mantine/core'
 import { useForm } from '@mantine/form'
+import { openConfirmModal } from '@mantine/modals'
 import { IconEdit, IconPlus, IconTrash } from '@tabler/icons-react'
 
 import type { Category } from '@/types/todo'
@@ -98,15 +99,24 @@ export function CategoryList() {
   }
 
   const handleDeleteCategory = async (categoryId: string) => {
-    if (!globalThis.confirm('このカテゴリを削除しますか？')) {
-      return
-    }
-
-    try {
-      await deleteCategory(categoryId)
-    } catch (error) {
-      console.error('カテゴリ削除エラー:', error)
-    }
+    openConfirmModal({
+      children: (
+        <Text size="sm">
+          このカテゴリを削除しますか？この操作は取り消せません。
+        </Text>
+      ),
+      confirmProps: { color: 'red' },
+      onConfirm: () => {
+        void (async () => {
+          try {
+            await deleteCategory(categoryId)
+          } catch (error) {
+            console.error('カテゴリ削除エラー:', error)
+          }
+        })()
+      },
+      title: '削除の確認',
+    })
   }
 
   const handleStartEdit = (category: Category) => {

--- a/src/components/todo/subtask-list.tsx
+++ b/src/components/todo/subtask-list.tsx
@@ -12,6 +12,7 @@ import {
   TextInput,
 } from '@mantine/core'
 import { useForm } from '@mantine/form'
+import { openConfirmModal } from '@mantine/modals'
 import { IconPlus, IconTrash } from '@tabler/icons-react'
 
 import { useSubTasks } from '@/hooks/use-subtasks'
@@ -70,15 +71,24 @@ export function SubTaskList({ todoId }: SubTaskListProps) {
   }
 
   const handleDeleteSubTask = async (subTaskId: string) => {
-    if (!globalThis.confirm('このサブタスクを削除しますか？')) {
-      return
-    }
-
-    try {
-      await deleteSubTask(subTaskId)
-    } catch (error) {
-      console.error('サブタスク削除エラー:', error)
-    }
+    openConfirmModal({
+      children: (
+        <Text size="sm">
+          このサブタスクを削除しますか？この操作は取り消せません。
+        </Text>
+      ),
+      confirmProps: { color: 'red' },
+      onConfirm: () => {
+        void (async () => {
+          try {
+            await deleteSubTask(subTaskId)
+          } catch (error) {
+            console.error('サブタスク削除エラー:', error)
+          }
+        })()
+      },
+      title: '削除の確認',
+    })
   }
 
   const handleCancel = () => {

--- a/src/components/todo/todo-item.test.tsx
+++ b/src/components/todo/todo-item.test.tsx
@@ -7,7 +7,6 @@ import { useTodoStore } from '@/stores/todo-store'
 import { useUiStore } from '@/stores/ui-store'
 import { fireEvent, render, screen } from '@/test-utils'
 
-
 // ストアのモック
 vi.mock('@/stores/todo-store', () => ({
   useTodoStore: vi.fn(),
@@ -226,6 +225,9 @@ describe('TodoItem', () => {
     // onConfirmコールバックを取得して実行
     const mockedOpenConfirmModal = vi.mocked(openConfirmModal)
     const onConfirmCallback = mockedOpenConfirmModal.mock.calls[0][0].onConfirm
+    if (!onConfirmCallback) {
+      throw new Error('onConfirm callback is not defined')
+    }
     onConfirmCallback()
 
     // Assert

--- a/src/components/todo/todo-item.test.tsx
+++ b/src/components/todo/todo-item.test.tsx
@@ -1,9 +1,12 @@
+import { openConfirmModal } from '@mantine/modals'
+
 import { TodoItem } from './todo-item'
 
 import { formatDate } from '@/lib/utils'
 import { useTodoStore } from '@/stores/todo-store'
 import { useUiStore } from '@/stores/ui-store'
 import { fireEvent, render, screen } from '@/test-utils'
+
 
 // ストアのモック
 vi.mock('@/stores/todo-store', () => ({
@@ -26,11 +29,14 @@ vi.mock('@tabler/icons-react', () => ({
   IconTrash: () => <div data-testid="icon-trash" />,
 }))
 
-// window.confirmのモック
-const mockConfirm = vi.fn()
-Object.defineProperty(globalThis, 'confirm', {
-  value: mockConfirm,
-  writable: true,
+// Mantine modalsのモック
+vi.mock('@mantine/modals', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importOriginal<typeof import('@mantine/modals')>()
+  return {
+    ...actual,
+    openConfirmModal: vi.fn(),
+  }
 })
 
 const mockToggleTodo = vi.fn()
@@ -75,7 +81,6 @@ describe('TodoItem', () => {
     vi.mocked(useTodoStore).mockReturnValue(mockTodoStore)
     vi.mocked(useUiStore).mockReturnValue(mockUiStore)
     vi.mocked(formatDate).mockReturnValue('2024年1月15日')
-    mockConfirm.mockReturnValue(true)
   })
 
   it('基本的なタスク情報が正しく表示される', () => {
@@ -193,7 +198,7 @@ describe('TodoItem', () => {
     expect(mockToggleTodo).toHaveBeenCalledWith('todo-1')
   })
 
-  it('削除ボタンをクリックして確認すると削除される', () => {
+  it('削除ボタンをクリックすると確認ダイアログが表示される', () => {
     // Act
     render(<TodoItem todo={mockTodo} />)
 
@@ -202,14 +207,15 @@ describe('TodoItem', () => {
     fireEvent.click(deleteButton)
 
     // Assert
-    expect(mockConfirm).toHaveBeenCalledWith('このタスクを削除しますか？')
-    expect(mockDeleteTodo).toHaveBeenCalledWith('todo-1')
+    expect(openConfirmModal).toHaveBeenCalledWith({
+      children: expect.any(Object),
+      confirmProps: { color: 'red' },
+      onConfirm: expect.any(Function),
+      title: '削除の確認',
+    })
   })
 
-  it('削除ボタンをクリックしてキャンセルすると削除されない', () => {
-    // Arrange
-    mockConfirm.mockReturnValue(false)
-
+  it('削除確認ダイアログでonConfirmが呼ばれるとdeleteTodoが実行される', () => {
     // Act
     render(<TodoItem todo={mockTodo} />)
 
@@ -217,9 +223,13 @@ describe('TodoItem', () => {
     const deleteButton = screen.getByTestId('icon-trash')
     fireEvent.click(deleteButton)
 
+    // onConfirmコールバックを取得して実行
+    const mockedOpenConfirmModal = vi.mocked(openConfirmModal)
+    const onConfirmCallback = mockedOpenConfirmModal.mock.calls[0][0].onConfirm
+    onConfirmCallback()
+
     // Assert
-    expect(mockConfirm).toHaveBeenCalledWith('このタスクを削除しますか？')
-    expect(mockDeleteTodo).not.toHaveBeenCalled()
+    expect(mockDeleteTodo).toHaveBeenCalledWith('todo-1')
   })
 
   it('タスクカードをクリックするとsetSelectedTodoが呼ばれる', () => {

--- a/src/components/todo/todo-item.tsx
+++ b/src/components/todo/todo-item.tsx
@@ -7,6 +7,7 @@ import {
   Stack,
   Text,
 } from '@mantine/core'
+import { openConfirmModal } from '@mantine/modals'
 import { IconCalendar, IconStar, IconTrash } from '@tabler/icons-react'
 
 import { formatDate } from '@/lib/utils'
@@ -41,9 +42,18 @@ export function TodoItem({ todo }: TodoItemProps) {
 
   const handleDelete = async (event: React.MouseEvent) => {
     event.stopPropagation()
-    if (globalThis.confirm('このタスクを削除しますか？')) {
-      await deleteTodo(todo.id)
-    }
+    openConfirmModal({
+      children: (
+        <Text size="sm">
+          このタスクを削除しますか？この操作は取り消せません。
+        </Text>
+      ),
+      confirmProps: { color: 'red' },
+      onConfirm: () => {
+        void deleteTodo(todo.id)
+      },
+      title: '削除の確認',
+    })
   }
 
   const handleClick = () => {

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react'
 
 import { MantineProvider } from '@mantine/core'
 import { DatesProvider } from '@mantine/dates'
+import { ModalsProvider } from '@mantine/modals'
 import { render } from '@testing-library/react'
 
 import type { RenderOptions } from '@testing-library/react'
@@ -17,9 +18,11 @@ import '@mantine/dates/styles.css'
 function AllTheProviders({ children }: { children: React.ReactNode }) {
   return (
     <MantineProvider>
-      <DatesProvider settings={{ firstDayOfWeek: 0, locale: 'ja' }}>
-        {children}
-      </DatesProvider>
+      <ModalsProvider>
+        <DatesProvider settings={{ firstDayOfWeek: 0, locale: 'ja' }}>
+          {children}
+        </DatesProvider>
+      </ModalsProvider>
     </MantineProvider>
   )
 }


### PR DESCRIPTION
## Summary
プレーンなwindow.confirmからMantineのopenConfirmModalに変更し、より美しい削除確認ダイアログを実装しました。

- TODOアイテム、サブタスク、カテゴリの削除確認をMantineダイアログに統一
- 日本語対応（タイトル、メッセージ、ボタンラベル）
- 確認ボタンを赤色にしてより明確なUI/UX
- ModalsProviderの設定とテストの更新

## Test plan
- [x] yarn format - フォーマットチェック
- [x] yarn lint - リントチェック  
- [x] yarn typecheck - 型チェック
- [x] yarn test - テスト実行
- [x] yarn build - ビルドチェック
- [x] 削除確認ダイアログの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)