### PR TITLE
test: add 100% coverage tests for API clients

### DIFF
--- a/src/lib/api/category-client.test.ts
+++ b/src/lib/api/category-client.test.ts
@@ -1,0 +1,379 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { categoryClient } from './category-client'
+
+import type { ApiResponse, Category } from '@/types/todo'
+
+/**
+ * category-client.tsのテスト
+ *
+ * 各APIメソッドの正常系・異常系・エッジケースを100%カバレッジでテスト
+ */
+
+// fetchのモック
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe('categoryClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(vi.fn())
+  })
+
+  describe('createCategory', () => {
+    it('should create category with valid data', async () => {
+      // Arrange
+      const categoryData = {
+        color: '#FF6B6B',
+        name: 'テストカテゴリ',
+      }
+      const expectedResponse: ApiResponse<Category> = {
+        data: {
+          color: '#FF6B6B',
+          createdAt: new Date('2024-01-01'),
+          id: 'category_123',
+          name: 'テストカテゴリ',
+          updatedAt: new Date('2024-01-01'),
+          userId: 'user_123',
+        },
+        success: true,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValueOnce(expectedResponse),
+        ok: true,
+      })
+
+      // Act
+      const result = await categoryClient.createCategory(categoryData)
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith('/api/categories', {
+        body: JSON.stringify(categoryData),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      })
+      expect(result).toEqual(expectedResponse)
+    })
+
+    it('should handle HTTP error response', async () => {
+      // Arrange
+      const categoryData = {
+        color: '#FF6B6B',
+        name: 'テストカテゴリ',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+      })
+
+      // Act & Assert
+      await expect(categoryClient.createCategory(categoryData)).rejects.toThrow(
+        'HTTP error! status: 400'
+      )
+      expect(console.error).toHaveBeenCalledWith(
+        'カテゴリ作成API呼び出しエラー:',
+        expect.any(Error)
+      )
+    })
+
+    it('should handle network error', async () => {
+      // Arrange
+      const categoryData = {
+        color: '#FF6B6B',
+        name: 'テストカテゴリ',
+      }
+      const networkError = new Error('Network error')
+
+      mockFetch.mockRejectedValueOnce(networkError)
+
+      // Act & Assert
+      await expect(categoryClient.createCategory(categoryData)).rejects.toThrow(
+        'Network error'
+      )
+      expect(console.error).toHaveBeenCalledWith(
+        'カテゴリ作成API呼び出しエラー:',
+        networkError
+      )
+    })
+  })
+
+  describe('deleteCategory', () => {
+    it('should delete category with valid id', async () => {
+      // Arrange
+      const categoryId = 'category_123'
+      const expectedResponse: ApiResponse<{ deleted: boolean; id: string }> = {
+        data: {
+          deleted: true,
+          id: categoryId,
+        },
+        success: true,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValueOnce(expectedResponse),
+        ok: true,
+      })
+
+      // Act
+      const result = await categoryClient.deleteCategory(categoryId)
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(`/api/categories/${categoryId}`, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'DELETE',
+      })
+      expect(result).toEqual(expectedResponse)
+    })
+
+    it('should handle HTTP error response', async () => {
+      // Arrange
+      const categoryId = 'category_123'
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      })
+
+      // Act & Assert
+      await expect(categoryClient.deleteCategory(categoryId)).rejects.toThrow(
+        'HTTP error! status: 404'
+      )
+      expect(console.error).toHaveBeenCalledWith(
+        'カテゴリ削除API呼び出しエラー:',
+        expect.any(Error)
+      )
+    })
+
+    it('should handle network error', async () => {
+      // Arrange
+      const categoryId = 'category_123'
+      const networkError = new Error('Network error')
+
+      mockFetch.mockRejectedValueOnce(networkError)
+
+      // Act & Assert
+      await expect(categoryClient.deleteCategory(categoryId)).rejects.toThrow(
+        'Network error'
+      )
+      expect(console.error).toHaveBeenCalledWith(
+        'カテゴリ削除API呼び出しエラー:',
+        networkError
+      )
+    })
+  })
+
+  describe('getCategories', () => {
+    it('should get categories list', async () => {
+      // Arrange
+      const expectedResponse: ApiResponse<Category[]> = {
+        data: [
+          {
+            color: '#FF6B6B',
+            createdAt: new Date('2024-01-01'),
+            id: 'category_123',
+            name: 'テストカテゴリ1',
+            updatedAt: new Date('2024-01-01'),
+            userId: 'user_123',
+          },
+          {
+            color: '#4ECDC4',
+            createdAt: new Date('2024-01-02'),
+            id: 'category_456',
+            name: 'テストカテゴリ2',
+            updatedAt: new Date('2024-01-02'),
+            userId: 'user_123',
+          },
+        ],
+        success: true,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValueOnce(expectedResponse),
+        ok: true,
+      })
+
+      // Act
+      const result = await categoryClient.getCategories()
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith('/api/categories', {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'GET',
+      })
+      expect(result).toEqual(expectedResponse)
+    })
+
+    it('should handle HTTP error response', async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      })
+
+      // Act & Assert
+      await expect(categoryClient.getCategories()).rejects.toThrow(
+        'HTTP error! status: 500'
+      )
+      expect(console.error).toHaveBeenCalledWith(
+        'カテゴリ取得API呼び出しエラー:',
+        expect.any(Error)
+      )
+    })
+
+    it('should handle network error', async () => {
+      // Arrange
+      const networkError = new Error('Network error')
+
+      mockFetch.mockRejectedValueOnce(networkError)
+
+      // Act & Assert
+      await expect(categoryClient.getCategories()).rejects.toThrow(
+        'Network error'
+      )
+      expect(console.error).toHaveBeenCalledWith(
+        'カテゴリ取得API呼び出しエラー:',
+        networkError
+      )
+    })
+  })
+
+  describe('updateCategory', () => {
+    it('should update category with valid data', async () => {
+      // Arrange
+      const categoryId = 'category_123'
+      const categoryData = {
+        color: '#45B7D1',
+        name: '更新されたカテゴリ',
+      }
+      const expectedResponse: ApiResponse<Category> = {
+        data: {
+          color: '#45B7D1',
+          createdAt: new Date('2024-01-01'),
+          id: categoryId,
+          name: '更新されたカテゴリ',
+          updatedAt: new Date('2024-01-02'),
+          userId: 'user_123',
+        },
+        success: true,
+        timestamp: '2024-01-02T00:00:00.000Z',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValueOnce(expectedResponse),
+        ok: true,
+      })
+
+      // Act
+      const result = await categoryClient.updateCategory(
+        categoryId,
+        categoryData
+      )
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(`/api/categories/${categoryId}`, {
+        body: JSON.stringify(categoryData),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'PUT',
+      })
+      expect(result).toEqual(expectedResponse)
+    })
+
+    it('should update category with partial data', async () => {
+      // Arrange
+      const categoryId = 'category_123'
+      const categoryData = {
+        name: '部分更新カテゴリ',
+      }
+      const expectedResponse: ApiResponse<Category> = {
+        data: {
+          color: '#FF6B6B',
+          createdAt: new Date('2024-01-01'),
+          id: categoryId,
+          name: '部分更新カテゴリ',
+          updatedAt: new Date('2024-01-02'),
+          userId: 'user_123',
+        },
+        success: true,
+        timestamp: '2024-01-02T00:00:00.000Z',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValueOnce(expectedResponse),
+        ok: true,
+      })
+
+      // Act
+      const result = await categoryClient.updateCategory(
+        categoryId,
+        categoryData
+      )
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(`/api/categories/${categoryId}`, {
+        body: JSON.stringify(categoryData),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'PUT',
+      })
+      expect(result).toEqual(expectedResponse)
+    })
+
+    it('should handle HTTP error response', async () => {
+      // Arrange
+      const categoryId = 'category_123'
+      const categoryData = {
+        color: '#45B7D1',
+        name: '更新されたカテゴリ',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+      })
+
+      // Act & Assert
+      await expect(
+        categoryClient.updateCategory(categoryId, categoryData)
+      ).rejects.toThrow('HTTP error! status: 400')
+      expect(console.error).toHaveBeenCalledWith(
+        'カテゴリ更新API呼び出しエラー:',
+        expect.any(Error)
+      )
+    })
+
+    it('should handle network error', async () => {
+      // Arrange
+      const categoryId = 'category_123'
+      const categoryData = {
+        color: '#45B7D1',
+        name: '更新されたカテゴリ',
+      }
+      const networkError = new Error('Network error')
+
+      mockFetch.mockRejectedValueOnce(networkError)
+
+      // Act & Assert
+      await expect(
+        categoryClient.updateCategory(categoryId, categoryData)
+      ).rejects.toThrow('Network error')
+      expect(console.error).toHaveBeenCalledWith(
+        'カテゴリ更新API呼び出しエラー:',
+        networkError
+      )
+    })
+  })
+})

--- a/src/lib/api/subtask-client.test.ts
+++ b/src/lib/api/subtask-client.test.ts
@@ -1,0 +1,430 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { subTaskClient } from './subtask-client'
+
+import type { ApiResponse, SubTask } from '@/types/todo'
+
+/**
+ * subtask-client.tsのテスト
+ *
+ * 各APIメソッドの正常系・異常系・エッジケースを100%カバレッジでテスト
+ */
+
+// fetchのモック
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe('subTaskClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('createSubTask', () => {
+    it('should create subtask with valid data', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const data = { title: 'テストサブタスク' }
+      const expectedResponse: ApiResponse<SubTask> = {
+        data: {
+          createdAt: new Date('2024-01-01'),
+          id: 'subtask_123',
+          isCompleted: false,
+          order: 0,
+          title: 'テストサブタスク',
+          todoId: todoId,
+          updatedAt: new Date('2024-01-01'),
+        },
+        success: true,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValueOnce(expectedResponse),
+        ok: true,
+      })
+
+      // Act
+      const result = await subTaskClient.createSubTask(todoId, data)
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(`/api/todos/${todoId}/subtasks`, {
+        body: JSON.stringify(data),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      })
+      expect(result).toEqual(expectedResponse)
+    })
+
+    it('should handle HTTP error response', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const data = { title: 'テストサブタスク' }
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+      })
+
+      // Act & Assert
+      await expect(subTaskClient.createSubTask(todoId, data)).rejects.toThrow(
+        'サブタスクの作成に失敗しました: 400'
+      )
+    })
+
+    it('should handle network error', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const data = { title: 'テストサブタスク' }
+      const networkError = new Error('Network error')
+
+      mockFetch.mockRejectedValueOnce(networkError)
+
+      // Act & Assert
+      await expect(subTaskClient.createSubTask(todoId, data)).rejects.toThrow(
+        'Network error'
+      )
+    })
+  })
+
+  describe('deleteSubTask', () => {
+    it('should delete subtask with valid id', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const subTaskId = 'subtask_123'
+      const expectedResponse: ApiResponse<{ deleted: boolean; id: string }> = {
+        data: {
+          deleted: true,
+          id: subTaskId,
+        },
+        success: true,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValueOnce(expectedResponse),
+        ok: true,
+      })
+
+      // Act
+      const result = await subTaskClient.deleteSubTask(todoId, subTaskId)
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        `/api/todos/${todoId}/subtasks/${subTaskId}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          method: 'DELETE',
+        }
+      )
+      expect(result).toEqual(expectedResponse)
+    })
+
+    it('should handle HTTP error response', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const subTaskId = 'subtask_123'
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      })
+
+      // Act & Assert
+      await expect(
+        subTaskClient.deleteSubTask(todoId, subTaskId)
+      ).rejects.toThrow('サブタスクの削除に失敗しました: 404')
+    })
+
+    it('should handle network error', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const subTaskId = 'subtask_123'
+      const networkError = new Error('Network error')
+
+      mockFetch.mockRejectedValueOnce(networkError)
+
+      // Act & Assert
+      await expect(
+        subTaskClient.deleteSubTask(todoId, subTaskId)
+      ).rejects.toThrow('Network error')
+    })
+  })
+
+  describe('getSubTasks', () => {
+    it('should get subtasks list for a todo', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const expectedResponse: ApiResponse<SubTask[]> = {
+        data: [
+          {
+            createdAt: new Date('2024-01-01'),
+            id: 'subtask_123',
+            isCompleted: false,
+            order: 0,
+            title: 'テストサブタスク1',
+            todoId: todoId,
+            updatedAt: new Date('2024-01-01'),
+          },
+          {
+            createdAt: new Date('2024-01-02'),
+            id: 'subtask_456',
+            isCompleted: true,
+            order: 1,
+            title: 'テストサブタスク2',
+            todoId: todoId,
+            updatedAt: new Date('2024-01-02'),
+          },
+        ],
+        success: true,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValueOnce(expectedResponse),
+        ok: true,
+      })
+
+      // Act
+      const result = await subTaskClient.getSubTasks(todoId)
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(`/api/todos/${todoId}/subtasks`, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'GET',
+      })
+      expect(result).toEqual(expectedResponse)
+    })
+
+    it('should handle HTTP error response', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      })
+
+      // Act & Assert
+      await expect(subTaskClient.getSubTasks(todoId)).rejects.toThrow(
+        'サブタスクの取得に失敗しました: 500'
+      )
+    })
+
+    it('should handle network error', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const networkError = new Error('Network error')
+
+      mockFetch.mockRejectedValueOnce(networkError)
+
+      // Act & Assert
+      await expect(subTaskClient.getSubTasks(todoId)).rejects.toThrow(
+        'Network error'
+      )
+    })
+  })
+
+  describe('toggleSubTask', () => {
+    it('should toggle subtask completion status', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const subTaskId = 'subtask_123'
+      const expectedResponse: ApiResponse<SubTask> = {
+        data: {
+          createdAt: new Date('2024-01-01'),
+          id: subTaskId,
+          isCompleted: true,
+          order: 0,
+          title: 'テストサブタスク',
+          todoId: todoId,
+          updatedAt: new Date('2024-01-02'),
+        },
+        success: true,
+        timestamp: '2024-01-02T00:00:00.000Z',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValueOnce(expectedResponse),
+        ok: true,
+      })
+
+      // Act
+      const result = await subTaskClient.toggleSubTask(todoId, subTaskId)
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        `/api/todos/${todoId}/subtasks/${subTaskId}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          method: 'PATCH',
+        }
+      )
+      expect(result).toEqual(expectedResponse)
+    })
+
+    it('should handle HTTP error response', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const subTaskId = 'subtask_123'
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      })
+
+      // Act & Assert
+      await expect(
+        subTaskClient.toggleSubTask(todoId, subTaskId)
+      ).rejects.toThrow('サブタスクの切り替えに失敗しました: 404')
+    })
+
+    it('should handle network error', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const subTaskId = 'subtask_123'
+      const networkError = new Error('Network error')
+
+      mockFetch.mockRejectedValueOnce(networkError)
+
+      // Act & Assert
+      await expect(
+        subTaskClient.toggleSubTask(todoId, subTaskId)
+      ).rejects.toThrow('Network error')
+    })
+  })
+
+  describe('updateSubTask', () => {
+    it('should update subtask with valid data', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const subTaskId = 'subtask_123'
+      const data = {
+        isCompleted: true,
+        title: '更新されたサブタスク',
+      }
+      const expectedResponse: ApiResponse<SubTask> = {
+        data: {
+          createdAt: new Date('2024-01-01'),
+          id: subTaskId,
+          isCompleted: true,
+          order: 0,
+          title: '更新されたサブタスク',
+          todoId: todoId,
+          updatedAt: new Date('2024-01-02'),
+        },
+        success: true,
+        timestamp: '2024-01-02T00:00:00.000Z',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValueOnce(expectedResponse),
+        ok: true,
+      })
+
+      // Act
+      const result = await subTaskClient.updateSubTask(todoId, subTaskId, data)
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        `/api/todos/${todoId}/subtasks/${subTaskId}`,
+        {
+          body: JSON.stringify(data),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          method: 'PUT',
+        }
+      )
+      expect(result).toEqual(expectedResponse)
+    })
+
+    it('should update subtask with partial data', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const subTaskId = 'subtask_123'
+      const data = {
+        title: '部分更新サブタスク',
+      }
+      const expectedResponse: ApiResponse<SubTask> = {
+        data: {
+          createdAt: new Date('2024-01-01'),
+          id: subTaskId,
+          isCompleted: false,
+          order: 0,
+          title: '部分更新サブタスク',
+          todoId: todoId,
+          updatedAt: new Date('2024-01-02'),
+        },
+        success: true,
+        timestamp: '2024-01-02T00:00:00.000Z',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValueOnce(expectedResponse),
+        ok: true,
+      })
+
+      // Act
+      const result = await subTaskClient.updateSubTask(todoId, subTaskId, data)
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        `/api/todos/${todoId}/subtasks/${subTaskId}`,
+        {
+          body: JSON.stringify(data),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          method: 'PUT',
+        }
+      )
+      expect(result).toEqual(expectedResponse)
+    })
+
+    it('should handle HTTP error response', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const subTaskId = 'subtask_123'
+      const data = {
+        isCompleted: true,
+        title: '更新されたサブタスク',
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+      })
+
+      // Act & Assert
+      await expect(
+        subTaskClient.updateSubTask(todoId, subTaskId, data)
+      ).rejects.toThrow('サブタスクの更新に失敗しました: 400')
+    })
+
+    it('should handle network error', async () => {
+      // Arrange
+      const todoId = 'todo_123'
+      const subTaskId = 'subtask_123'
+      const data = {
+        isCompleted: true,
+        title: '更新されたサブタスク',
+      }
+      const networkError = new Error('Network error')
+
+      mockFetch.mockRejectedValueOnce(networkError)
+
+      // Act & Assert
+      await expect(
+        subTaskClient.updateSubTask(todoId, subTaskId, data)
+      ).rejects.toThrow('Network error')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- category-client.test.ts with 13 comprehensive test cases
- subtask-client.test.ts with 16 comprehensive test cases  
- 100% code coverage achieved for both API client modules
- All CRUD operations tested with success and error scenarios

## Test Coverage Details
- **category-client.ts**: 100% (Statements, Branches, Functions, Lines)
- **subtask-client.ts**: 100% (Statements, Branches, Functions, Lines)
- **Total Tests**: 29 tests passing

## Test Plan
- [x] 正常系: 有効なパラメータでの成功レスポンス
- [x] 異常系: HTTPエラーレスポンス (400, 404, 500)
- [x] 異常系: ネットワークエラー
- [x] エラーハンドリング: console.error呼び出し確認
- [x] APIコール: 正しいHTTPメソッド・ヘッダー・URL確認
- [x] 型安全性: レスポンスの型チェック
- [x] モック化: fetchのモック実装

🤖 Generated with [Claude Code](https://claude.ai/code)