### PR TITLE
Fix flaky category modal test

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -145,6 +145,7 @@ const eslintConfig = tseslint.config(
       '**/public/**',
       '**/coverage/**',
       '**/mcp-server/**',
+      '**/.yarn/**',
     ],
   }
 )

--- a/src/components/category/category-create-modal.test.tsx
+++ b/src/components/category/category-create-modal.test.tsx
@@ -330,7 +330,9 @@ describe('CategoryCreateModal', () => {
     })
 
     // モーダルは開いたまま
-    expect(mockOnClose).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(mockOnClose).not.toHaveBeenCalled()
+    })
 
     consoleSpy.mockRestore()
   })


### PR DESCRIPTION
## Summary
- stabilize `CategoryCreateModal` error handling test by awaiting not-to-be-called assertion
- ignore `.yarn` directory in ESLint config

## Testing
- `yarn format`
- `yarn typecheck`
- `yarn lint`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_686d394089748327a2c390b3e693016b