### PR TITLE
Fix CategoryCreateModal test flakiness

### DIFF
--- a/src/components/category/category-create-modal.test.tsx
+++ b/src/components/category/category-create-modal.test.tsx
@@ -329,10 +329,12 @@ describe('CategoryCreateModal', () => {
       )
     })
 
-    // モーダルは開いたまま
     await waitFor(() => {
-      expect(mockOnClose).not.toHaveBeenCalled()
+      expect(mockCreateCategory).toHaveBeenCalled()
     })
+
+    // モーダルは開いたまま
+    expect(mockOnClose).not.toHaveBeenCalled()
 
     consoleSpy.mockRestore()
   })


### PR DESCRIPTION
## Summary
- stabilize the error handling test in CategoryCreateModal

## Testing
- `yarn test src/components/category/category-create-modal.test.tsx`
- `yarn test`
- `yarn lint`
- `yarn typecheck`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_686dc20256a483278892e04e12269797