### PR TITLE
fix: keep modal open on error

### DIFF
--- a/src/components/category/category-create-modal.test.tsx
+++ b/src/components/category/category-create-modal.test.tsx
@@ -339,6 +339,23 @@ describe('CategoryCreateModal', () => {
     consoleSpy.mockRestore()
   })
 
+  it('Escapeキーでモーダルが閉じない', () => {
+    // Act
+    render(
+      <CategoryCreateModal
+        onCategoryCreated={mockOnCategoryCreated}
+        onClose={mockOnClose}
+        opened={true}
+      />
+    )
+
+    // Act - Escapeキーを押す
+    fireEvent.keyDown(document, { code: 'Escape', key: 'Escape' })
+
+    // Assert
+    expect(mockOnClose).not.toHaveBeenCalled()
+  })
+
   it('アイコンが正しく表示される', () => {
     // Act
     render(

--- a/src/components/category/category-create-modal.tsx
+++ b/src/components/category/category-create-modal.tsx
@@ -75,6 +75,8 @@ export function CategoryCreateModal({
 
   return (
     <Modal
+      closeOnClickOutside={false}
+      closeOnEscape={false}
       onClose={onClose}
       opened={opened}
       size="md"


### PR DESCRIPTION
## Summary
- prevent CategoryCreateModal from closing on Escape or outside click
- add regression test for Escape key

## Testing
- `yarn format`
- `yarn typecheck`
- `yarn lint`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_686e2d0ae42c832790cbf9b3e879da85