### PR TITLE
Fix CI vitest memory issue

### DIFF
--- a/src/tests/config/vitest-config.test.ts
+++ b/src/tests/config/vitest-config.test.ts
@@ -1,0 +1,14 @@
+import fs from 'fs'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * vitest.config.ts の CI向け設定を確認します
+ */
+describe('vitest.config CI settings', () => {
+  it('maxWorkers 設定が含まれている', () => {
+    const configPath = path.resolve(__dirname, '../../../vitest.config.ts')
+    const configContent = fs.readFileSync(configPath, 'utf-8')
+    expect(configContent).toMatch(/maxWorkers: process\.env\.CI \? 1 : undefined/)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,6 +34,10 @@ export default defineConfig({
     },
     environment: 'jsdom',
     globals: true,
+    /**
+     * CI環境ではメモリ不足を防ぐためテストワーカー数を1に制限します
+     */
+    maxWorkers: process.env.CI ? 1 : undefined,
     setupFiles: ['./src/tests/setup.ts'],
   },
 })


### PR DESCRIPTION
## Summary
- limit maxWorkers on Vitest when running in CI to avoid OOM
- add a regression test verifying config

## Testing
- `yarn format`
- `yarn typecheck`
- `yarn lint`
- `yarn test src/tests/config/vitest-config.test.ts`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_686f0a6d131883278b449f931404473b