### PR TITLE
test: add coverage for auth and provider

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.test.ts
+++ b/src/app/api/auth/[...nextauth]/route.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth', () => ({ handlers: { GET: 'get', POST: 'post' } }))
+
+const route = await import('./route')
+
+describe('auth route', () => {
+  it('handlers をそのままエクスポートしている', () => {
+    expect(route.GET).toBe('get')
+    expect(route.POST).toBe('post')
+  })
+})

--- a/src/app/api/mcp/route.test.ts
+++ b/src/app/api/mcp/route.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const toolMock = vi.fn()
+
+vi.mock('@vercel/mcp-adapter', () => ({
+  createMcpHandler: vi.fn((setup: (srv: { tool: typeof toolMock }) => void) => {
+    setup({ tool: toolMock })
+    return 'handler'
+  }),
+}))
+
+vi.mock('@/lib/mcp/tools', () => ({
+  completeTodo: vi.fn(async (p) => `complete-${JSON.stringify(p)}`),
+  createTodo: vi.fn(async (p) => `create-${JSON.stringify(p)}`),
+  deleteTodo: vi.fn(async (p) => `delete-${JSON.stringify(p)}`),
+  listTodos: vi.fn(async (p) => `list-${JSON.stringify(p)}`),
+}))
+
+const tools = await import('@/lib/mcp/tools')
+const { GET, POST } = await import('./route')
+
+const { completeTodo, createTodo, deleteTodo, listTodos } = tools
+
+describe('mcp route', () => {
+  it('createMcpHandlerが正しく呼び出される', async () => {
+    expect(GET).toBe('handler')
+    expect(POST).toBe('handler')
+
+    expect(toolMock).toHaveBeenCalledTimes(4)
+    expect(toolMock.mock.calls[0][0]).toBe('list-todos')
+    expect(toolMock.mock.calls[1][0]).toBe('create-todo')
+    expect(toolMock.mock.calls[2][0]).toBe('complete-todo')
+    expect(toolMock.mock.calls[3][0]).toBe('delete-todo')
+  })
+
+  it('登録されたツールが各関数を呼び出す', async () => {
+    const cbList = toolMock.mock.calls[0][3]
+    const cbCreate = toolMock.mock.calls[1][3]
+    const cbComplete = toolMock.mock.calls[2][3]
+    const cbDelete = toolMock.mock.calls[3][3]
+
+    await cbList({ a: 1 })
+    await cbCreate({ b: 2 })
+    await cbComplete({ c: 3 })
+    await cbDelete({ d: 4 })
+
+    expect(listTodos).toHaveBeenCalledWith({ a: 1 })
+    expect(createTodo).toHaveBeenCalledWith({ b: 2 })
+    expect(completeTodo).toHaveBeenCalledWith({ c: 3 })
+    expect(deleteTodo).toHaveBeenCalledWith({ d: 4 })
+  })
+})

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auth/prisma-adapter', () => ({
+  PrismaAdapter: vi.fn(() => 'adapter'),
+}))
+vi.mock('next-auth/providers/google', () => ({
+  default: vi.fn(() => 'google'),
+}))
+vi.mock('next-auth/providers/github', () => ({
+  default: vi.fn(() => 'github'),
+}))
+vi.mock('next-auth/providers/microsoft-entra-id', () => ({
+  default: vi.fn(() => 'microsoft'),
+}))
+
+vi.mock('@/lib/db', () => ({ prisma: 'prisma' }))
+
+interface NextAuthCallbacks {
+  session: ({ session, user }: { session: { user?: { id?: string } }; user: { id: string } }) => Promise<{ user?: { id?: string } }>
+  signIn: (args: { account?: { provider: string }; profile?: { login?: string; name?: string; }; user: { name?: string } }) => Promise<boolean>
+}
+interface NextAuthConfig {
+  adapter: unknown
+  callbacks: NextAuthCallbacks
+  debug: boolean
+  pages: { signIn: string }
+  providers: unknown[]
+  session: { strategy: string }
+}
+
+let capturedConfig: NextAuthConfig | undefined
+vi.mock('next-auth', () => ({
+  default: vi.fn((config: NextAuthConfig) => {
+    capturedConfig = config
+    return {
+      auth: 'auth',
+      handlers: { GET: 'get', POST: 'post' },
+      signIn: 'nextSignIn',
+      signOut: 'nextSignOut',
+    }
+  }),
+}))
+
+const loadModule = async () => await import('./auth')
+
+beforeAll(async () => {
+  await loadModule()
+})
+
+describe('auth configuration', () => {
+  it('NextAuthが正しい設定で呼び出される', async () => {
+    const mod = await loadModule()
+
+    expect(mod.auth).toBe('auth')
+    expect(mod.handlers.GET).toBe('get')
+    expect(mod.handlers.POST).toBe('post')
+    expect(mod.signIn).toBe('nextSignIn')
+    expect(mod.signOut).toBe('nextSignOut')
+
+    expect(capturedConfig!.adapter).toBe('adapter')
+    expect(capturedConfig!.session.strategy).toBe('database')
+    expect(capturedConfig!.pages.signIn).toBe('/auth/signin')
+    expect(capturedConfig!.debug).toBe(false)
+    expect(capturedConfig!.providers).toEqual(['google', 'microsoft', 'github'])
+  })
+
+  it('session callbackがユーザーIDを設定する', async () => {
+    await loadModule()
+    const session: { user?: { id?: string; name?: string } } = { user: { name: 'u' } }
+    const user = { id: 'id1' }
+    const result = await capturedConfig!.callbacks.session({ session, user })
+    expect(result.user?.id).toBe('id1')
+  })
+
+  it('session callbackはユーザーがない場合そのまま返す', async () => {
+    await loadModule()
+    const session: { user?: { id?: string } } = {}
+    const user = { id: 'id1' }
+    const result = await capturedConfig!.callbacks.session({ session, user })
+    expect(result).toBe(session)
+  })
+
+  it('signIn callbackがGoogleプロフィールから名前を設定する', async () => {
+    await loadModule()
+    const user: { name?: string } = {}
+    await capturedConfig!.callbacks.signIn({
+      account: { provider: 'google' },
+      profile: { name: 'John' },
+      user,
+    })
+    expect(user.name).toBe('John')
+  })
+
+  it('signIn callbackがGitHubプロフィールから名前を設定する', async () => {
+    await loadModule()
+    const user: { name?: string } = {}
+    await capturedConfig!.callbacks.signIn({
+      account: { provider: 'github' },
+      profile: { login: 'john' },
+      user,
+    })
+    expect(user.name).toBe('john')
+  })
+
+  it('signIn callbackがMicrosoftプロフィールから名前を設定する', async () => {
+    await loadModule()
+    const user: { name?: string } = {}
+    await capturedConfig!.callbacks.signIn({
+      account: { provider: 'microsoft-entra-id' },
+      profile: { name: 'Mike' },
+      user,
+    })
+    expect(user.name).toBe('Mike')
+  })
+
+  it('signIn callbackは既に名前がある場合変更しない', async () => {
+    await loadModule()
+    const user: { name?: string } = { name: 'Exists' }
+    await capturedConfig!.callbacks.signIn({
+      account: { provider: 'google' },
+      profile: { name: 'John' },
+      user,
+    })
+    expect(user.name).toBe('Exists')
+  })
+
+  it('signIn callbackはaccountがない場合何もしない', async () => {
+    await loadModule()
+    const user: { name?: string } = {}
+    await capturedConfig!.callbacks.signIn({
+      account: undefined,
+      profile: undefined,
+      user,
+    })
+    expect(user.name).toBeUndefined()
+  })
+})

--- a/src/components/category/category-list.test.tsx
+++ b/src/components/category/category-list.test.tsx
@@ -297,4 +297,89 @@ describe('CategoryList', () => {
     ).not.toBeInTheDocument()
     expect(mockCreateCategory).not.toHaveBeenCalled()
   })
+
+  it('カテゴリを編集して保存できる', async () => {
+    render(<CategoryList />)
+    const editButtons = screen.getAllByTestId('icon-edit')
+    fireEvent.click(editButtons[0])
+
+    const nameInput = screen.getByPlaceholderText('カテゴリ名を入力...')
+    fireEvent.change(nameInput, { target: { value: '編集後' } })
+
+    const saveButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(mockUpdateCategory).toHaveBeenCalledWith('category-1', {
+        color: '#FF6B6B',
+        name: '編集後',
+      })
+    })
+  })
+
+  it('編集をキャンセルすると変更されない', () => {
+    render(<CategoryList />)
+    const editButtons = screen.getAllByTestId('icon-edit')
+    fireEvent.click(editButtons[0])
+
+    const nameInput = screen.getByPlaceholderText('カテゴリ名を入力...')
+    fireEvent.change(nameInput, { target: { value: '編集後' } })
+
+    const cancelButton = screen.getByRole('button', { name: 'キャンセル' })
+    fireEvent.click(cancelButton)
+
+    expect(
+      screen.queryByPlaceholderText('カテゴリ名を入力...')
+    ).not.toBeInTheDocument()
+    expect(mockUpdateCategory).not.toHaveBeenCalled()
+  })
+
+  it('カテゴリ作成エラー時にconsole.errorが呼ばれる', async () => {
+    mockCreateCategory.mockRejectedValueOnce(new Error('err'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    render(<CategoryList />)
+    const addButton = screen.getByRole('button', { name: 'カテゴリを追加' })
+    fireEvent.click(addButton)
+    const nameInput = screen.getByPlaceholderText('カテゴリ名を入力...')
+    fireEvent.change(nameInput, { target: { value: 'abc' } })
+    const saveButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalled()
+    })
+    errorSpy.mockRestore()
+  })
+
+  it('カテゴリ更新エラー時にconsole.errorが呼ばれる', async () => {
+    mockUpdateCategory.mockRejectedValueOnce(new Error('err'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    render(<CategoryList />)
+    const editButtons = screen.getAllByTestId('icon-edit')
+    fireEvent.click(editButtons[0])
+    const saveButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalled()
+    })
+    errorSpy.mockRestore()
+  })
+
+  it('カテゴリ削除エラー時にconsole.errorが呼ばれる', async () => {
+    mockDeleteCategory.mockRejectedValueOnce(new Error('err'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    render(<CategoryList />)
+    const deleteButtons = screen.getAllByTestId('icon-trash')
+    fireEvent.click(deleteButtons[0])
+    if (mockConfirmCallback) mockConfirmCallback()
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalled()
+    })
+    errorSpy.mockRestore()
+  })
 })

--- a/src/components/providers/app-provider.test.tsx
+++ b/src/components/providers/app-provider.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen } from '@/test-utils'
+
+const mockUseUserStore = vi.fn()
+vi.mock('@/stores/user-store', () => ({
+  useUserStore: mockUseUserStore,
+}))
+
+const setUser = vi.fn()
+mockUseUserStore.mockReturnValue({ setUser })
+
+const { AppProvider } = await import('./app-provider')
+
+describe('AppProvider', () => {
+  it('子要素を表示しデモユーザーを設定する', () => {
+    render(
+      <AppProvider>
+        <div>child</div>
+      </AppProvider>
+    )
+
+    expect(screen.getByText('child')).toBeInTheDocument()
+    expect(setUser).toHaveBeenCalledTimes(1)
+    expect(setUser.mock.calls[0][0]).toMatchObject({
+      email: 'demo@example.com',
+      id: 'user-1',
+      name: 'デモユーザー',
+    })
+  })
+
+  it('再レンダリングしてもsetUserは1回だけ呼ばれる', () => {
+    const { rerender } = render(
+      <AppProvider>
+        <span>first</span>
+      </AppProvider>
+    )
+    rerender(
+      <AppProvider>
+        <span>second</span>
+      </AppProvider>
+    )
+
+    expect(screen.getByText('second')).toBeInTheDocument()
+    expect(setUser).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary
- add NextAuth config tests
- add MCP route tests
- expand CategoryList coverage
- add AppProvider tests

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6871d8e9ef548327bfc0637d65443a3a