### PR TITLE
feat: ユーザーアバタークリック時のログアウト機能を実装

### DIFF
--- a/src/components/auth/logout-confirmation-modal.test.tsx
+++ b/src/components/auth/logout-confirmation-modal.test.tsx
@@ -1,0 +1,187 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LogoutConfirmationModal } from './logout-confirmation-modal'
+
+import { renderWithProviders } from '@/test-utils'
+
+describe('LogoutConfirmationModal', () => {
+  it('モーダルが開いている時、確認メッセージが表示される', () => {
+    // Arrange
+    const mockOnClose = vi.fn()
+    const mockOnConfirm = vi.fn()
+
+    // Act
+    renderWithProviders(
+      <LogoutConfirmationModal
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        opened={true}
+      />
+    )
+
+    // Assert
+    expect(screen.getByText('ログアウトしますか？')).toBeInTheDocument()
+    expect(
+      screen.getByText('ログアウトすると、再度ログインが必要になります。')
+    ).toBeInTheDocument()
+  })
+
+  it('モーダルが閉じている時、確認メッセージが表示されない', () => {
+    // Arrange
+    const mockOnClose = vi.fn()
+    const mockOnConfirm = vi.fn()
+
+    // Act
+    renderWithProviders(
+      <LogoutConfirmationModal
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        opened={false}
+      />
+    )
+
+    // Assert
+    expect(screen.queryByText('ログアウトしますか？')).not.toBeInTheDocument()
+  })
+
+  it('ログアウトボタンが赤色でログアウトアイコン付きで表示される', () => {
+    // Arrange
+    const mockOnClose = vi.fn()
+    const mockOnConfirm = vi.fn()
+
+    // Act
+    renderWithProviders(
+      <LogoutConfirmationModal
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        opened={true}
+      />
+    )
+
+    // Assert
+    const logoutButton = screen.getByRole('button', { name: /ログアウト/i })
+    expect(logoutButton).toBeInTheDocument()
+    expect(logoutButton).toHaveClass('mantine-Button-root')
+
+    // アイコンが存在することを確認
+    const icon = logoutButton.querySelector('svg')
+    expect(icon).toBeInTheDocument()
+  })
+
+  it('キャンセルボタンが表示される', () => {
+    // Arrange
+    const mockOnClose = vi.fn()
+    const mockOnConfirm = vi.fn()
+
+    // Act
+    renderWithProviders(
+      <LogoutConfirmationModal
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        opened={true}
+      />
+    )
+
+    // Assert
+    const cancelButton = screen.getByRole('button', { name: /キャンセル/i })
+    expect(cancelButton).toBeInTheDocument()
+  })
+
+  it('ログアウトボタンクリック時にonConfirmが呼ばれる', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const mockOnClose = vi.fn()
+    const mockOnConfirm = vi.fn()
+
+    renderWithProviders(
+      <LogoutConfirmationModal
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        opened={true}
+      />
+    )
+
+    // Act
+    const logoutButton = screen.getByRole('button', { name: /ログアウト/i })
+    await user.click(logoutButton)
+
+    // Assert
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('キャンセルボタンクリック時にonCloseが呼ばれる', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const mockOnClose = vi.fn()
+    const mockOnConfirm = vi.fn()
+
+    renderWithProviders(
+      <LogoutConfirmationModal
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        opened={true}
+      />
+    )
+
+    // Act
+    const cancelButton = screen.getByRole('button', { name: /キャンセル/i })
+    await user.click(cancelButton)
+
+    // Assert
+    expect(mockOnClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('モーダルの閉じるボタンクリック時にonCloseが呼ばれる', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const mockOnClose = vi.fn()
+    const mockOnConfirm = vi.fn()
+
+    renderWithProviders(
+      <LogoutConfirmationModal
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        opened={true}
+      />
+    )
+
+    // Act
+    // すべてのボタンを取得し、ログアウトとキャンセル以外のボタン（クローズボタン）を見つける
+    const allButtons = screen.getAllByRole('button')
+    const closeButton = allButtons.find(
+      (button) =>
+        !button.textContent?.includes('ログアウト') &&
+        !button.textContent?.includes('キャンセル')
+    )
+
+    if (closeButton) {
+      await user.click(closeButton)
+    }
+
+    // Assert
+    expect(mockOnClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('ESCキー押下時にonCloseが呼ばれる', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const mockOnClose = vi.fn()
+    const mockOnConfirm = vi.fn()
+
+    renderWithProviders(
+      <LogoutConfirmationModal
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        opened={true}
+      />
+    )
+
+    // Act
+    await user.keyboard('{Escape}')
+
+    // Assert
+    expect(mockOnClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/auth/logout-confirmation-modal.tsx
+++ b/src/components/auth/logout-confirmation-modal.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { Button, Group, Modal, Stack, Text } from '@mantine/core'
+import { IconLogout } from '@tabler/icons-react'
+
+interface LogoutConfirmationModalProps {
+  onClose: () => void
+  onConfirm: () => void
+  opened: boolean
+}
+
+/**
+ * ログアウト確認モーダルコンポーネント
+ *
+ * ユーザーがログアウトを選択した際に表示される確認ダイアログです。
+ * - ログアウトの確認メッセージを表示
+ * - ログアウト/キャンセルボタンを提供
+ * - ESCキーやXボタンでモーダルを閉じる機能
+ */
+export function LogoutConfirmationModal({
+  onClose,
+  onConfirm,
+  opened,
+}: LogoutConfirmationModalProps) {
+  return (
+    <Modal
+      centered
+      onClose={onClose}
+      opened={opened}
+      size="sm"
+      title="ログアウト確認"
+    >
+      <Stack gap="md">
+        <Text fw={500} size="lg">
+          ログアウトしますか？
+        </Text>
+        <Text c="dimmed" size="sm">
+          ログアウトすると、再度ログインが必要になります。
+        </Text>
+        <Group gap="sm" justify="flex-end">
+          <Button onClick={onClose} variant="subtle">
+            キャンセル
+          </Button>
+          <Button
+            color="red"
+            leftSection={<IconLogout size={16} />}
+            onClick={onConfirm}
+          >
+            ログアウト
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  )
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,6 +1,7 @@
-import { ActionIcon, Avatar, Group, TextInput, Title } from '@mantine/core'
+import { ActionIcon, Group, TextInput, Title } from '@mantine/core'
 import { IconHelp, IconSearch, IconSettings } from '@tabler/icons-react'
 
+import { UserAvatarMenu } from '@/components/layout/user-avatar-menu'
 import { useClientOnly } from '@/hooks/use-client-only'
 import { generateUserInitials } from '@/lib/utils'
 import { useUserStore } from '@/stores/user-store'
@@ -52,7 +53,13 @@ export function Header() {
         <ActionIcon size="lg" variant="subtle">
           <IconHelp size={18} />
         </ActionIcon>
-        {isClient && <Avatar name={avatarName} size="sm" src={avatarSrc} />}
+        {isClient && (
+          <UserAvatarMenu
+            avatarName={avatarName}
+            avatarSrc={avatarSrc}
+            user={user}
+          />
+        )}
       </Group>
     </Group>
   )

--- a/src/components/layout/user-avatar-menu.test.tsx
+++ b/src/components/layout/user-avatar-menu.test.tsx
@@ -1,0 +1,244 @@
+import {
+  fireEvent,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { UserAvatarMenu } from './user-avatar-menu'
+
+import { renderWithProviders } from '@/test-utils'
+
+// next-auth/reactをモック
+vi.mock('next-auth/react', () => ({
+  signOut: vi.fn(),
+}))
+
+const { signOut } = await import('next-auth/react')
+const mockSignOut = vi.mocked(signOut)
+
+describe('UserAvatarMenu', () => {
+  const mockUser = {
+    createdAt: new Date(),
+    email: 'test@example.com',
+    id: 'user-1',
+    name: 'テスト ユーザー',
+    updatedAt: new Date(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('ユーザーが設定されている場合、アバターが表示される', () => {
+    // Arrange & Act
+    renderWithProviders(
+      <UserAvatarMenu avatarName="テユ" avatarSrc={undefined} user={mockUser} />
+    )
+
+    // Assert
+    expect(screen.getByText('テユ')).toBeInTheDocument()
+  })
+
+  it('ユーザー画像が設定されている場合、画像が表示される', () => {
+    // Arrange & Act
+    renderWithProviders(
+      <UserAvatarMenu
+        avatarName="テユ"
+        avatarSrc="https://example.com/avatar.jpg"
+        user={mockUser}
+      />
+    )
+
+    // Assert
+    const avatar = screen.getByRole('img', { hidden: true })
+    expect(avatar).toBeInTheDocument()
+  })
+
+  it('ユーザーが未設定の場合、デフォルト状態で表示される', () => {
+    // Arrange & Act
+    renderWithProviders(
+      <UserAvatarMenu
+        avatarName={undefined}
+        avatarSrc={undefined}
+        user={undefined}
+      />
+    )
+
+    // Assert
+    // Avatarコンポーネント自体は表示されるはず
+    const container = screen.getByTestId('user-avatar-menu')
+    expect(container).toBeInTheDocument()
+  })
+
+  it('アバターをクリックするとドロップダウンメニューが開く', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    renderWithProviders(
+      <UserAvatarMenu avatarName="テユ" avatarSrc={undefined} user={mockUser} />
+    )
+
+    // Act
+    const avatar = screen.getByText('テユ')
+    await user.click(avatar)
+
+    // Wait for menu to appear
+    await screen.findByRole('menu')
+
+    // Assert
+    expect(screen.getByText('ログアウト')).toBeInTheDocument()
+  })
+
+  it('ドロップダウンメニューに赤文字でログアウトアイコン付きのオプションが表示される', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    renderWithProviders(
+      <UserAvatarMenu avatarName="テユ" avatarSrc={undefined} user={mockUser} />
+    )
+
+    // Act
+    const avatar = screen.getByText('テユ')
+    await user.click(avatar)
+
+    // Wait for menu to appear
+    await screen.findByRole('menu')
+
+    // Assert
+    const logoutOption = screen.getByText('ログアウト')
+    expect(logoutOption).toBeInTheDocument()
+
+    // アイコンが存在することを確認
+    const menuItem = logoutOption.closest('[role="menuitem"]')
+    const icon = menuItem?.querySelector('svg')
+    expect(icon).toBeInTheDocument()
+  })
+
+  it('ログアウトオプションをクリックすると確認モーダルが表示される', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    renderWithProviders(
+      <UserAvatarMenu avatarName="テユ" avatarSrc={undefined} user={mockUser} />
+    )
+
+    // Act
+    const avatar = screen.getByText('テユ')
+    await user.click(avatar)
+
+    // Wait for menu to appear
+    await screen.findByRole('menu')
+
+    const logoutOption = screen.getByText('ログアウト')
+    // Use fireEvent for non-visible elements
+    fireEvent.click(logoutOption)
+
+    // Assert
+    expect(await screen.findByText('ログアウトしますか？')).toBeInTheDocument()
+  })
+
+  it('確認モーダルでログアウトを確認するとsignOutが呼ばれる', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    renderWithProviders(
+      <UserAvatarMenu avatarName="テユ" avatarSrc={undefined} user={mockUser} />
+    )
+
+    // Act
+    const avatar = screen.getByText('テユ')
+    await user.click(avatar)
+
+    // Wait for menu to appear
+    await screen.findByRole('menu')
+
+    const logoutOption = screen.getByText('ログアウト')
+    fireEvent.click(logoutOption)
+
+    const confirmButton = await screen.findByRole('button', {
+      name: /ログアウト/i,
+    })
+    await user.click(confirmButton)
+
+    // Assert
+    expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: '/auth/signin' })
+  })
+
+  it('確認モーダルでキャンセルするとモーダルが閉じる', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    renderWithProviders(
+      <UserAvatarMenu avatarName="テユ" avatarSrc={undefined} user={mockUser} />
+    )
+
+    // Act
+    const avatar = screen.getByText('テユ')
+    await user.click(avatar)
+
+    // Wait for menu to appear
+    await screen.findByRole('menu')
+
+    const logoutOption = screen.getByText('ログアウト')
+    fireEvent.click(logoutOption)
+
+    const cancelButton = await screen.findByRole('button', {
+      name: /キャンセル/i,
+    })
+    await user.click(cancelButton)
+
+    // Assert - モーダルが削除されるまで待つ
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText('ログアウトしますか？')
+    )
+  })
+
+  it('ESCキーでモーダルが閉じる', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    renderWithProviders(
+      <UserAvatarMenu avatarName="テユ" avatarSrc={undefined} user={mockUser} />
+    )
+
+    // Act
+    const avatar = screen.getByText('テユ')
+    await user.click(avatar)
+
+    // Wait for menu to appear
+    await screen.findByRole('menu')
+
+    const logoutOption = screen.getByText('ログアウト')
+    fireEvent.click(logoutOption)
+
+    // Wait for modal to appear
+    await screen.findByText('ログアウトしますか？')
+
+    await user.keyboard('{Escape}')
+
+    // Assert - モーダルが削除されるまで待つ
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText('ログアウトしますか？')
+    )
+  })
+
+  it('ドロップダウンメニュー外をクリックするとメニューが閉じる', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    renderWithProviders(
+      <UserAvatarMenu avatarName="テユ" avatarSrc={undefined} user={mockUser} />
+    )
+
+    // Act
+    const avatar = screen.getByText('テユ')
+    await user.click(avatar)
+
+    // Wait for menu to appear
+    const menu = await screen.findByRole('menu')
+
+    // メニューが開いていることを確認
+    expect(screen.getByText('ログアウト')).toBeInTheDocument()
+
+    // 外部をクリック
+    await user.click(document.body)
+
+    // Assert - メニューが削除されるまで待つ
+    await waitForElementToBeRemoved(menu)
+  })
+})

--- a/src/components/layout/user-avatar-menu.tsx
+++ b/src/components/layout/user-avatar-menu.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Avatar, Menu } from '@mantine/core'
+import { IconLogout } from '@tabler/icons-react'
+import { signOut } from 'next-auth/react'
+
+import type { User } from '@/types/todo'
+
+import { LogoutConfirmationModal } from '@/components/auth/logout-confirmation-modal'
+
+interface UserAvatarMenuProps {
+  avatarName?: string
+  avatarSrc?: string
+  user: undefined | User
+}
+
+/**
+ * ユーザーアバターメニューコンポーネント
+ *
+ * ユーザーのアバターをクリックするとドロップダウンメニューを表示します。
+ * - アバター表示（画像またはイニシャル）
+ * - ログアウトオプション（赤文字 + ログアウトアイコン）
+ * - ログアウト確認モーダル
+ * - NextAuth.js signOut 統合
+ */
+export function UserAvatarMenu({
+  avatarName,
+  avatarSrc,
+  user: _user,
+}: UserAvatarMenuProps) {
+  const [logoutModalOpened, setLogoutModalOpened] = useState(false)
+
+  const handleLogout = () => {
+    setLogoutModalOpened(true)
+  }
+
+  const handleConfirmLogout = async () => {
+    await signOut({ callbackUrl: '/auth/signin' })
+    setLogoutModalOpened(false)
+  }
+
+  const handleCancelLogout = () => {
+    setLogoutModalOpened(false)
+  }
+
+  return (
+    <div data-testid="user-avatar-menu">
+      <Menu position="bottom-end" withinPortal={false}>
+        <Menu.Target>
+          <Avatar
+            name={avatarName}
+            size="sm"
+            src={avatarSrc}
+            style={{ cursor: 'pointer' }}
+          />
+        </Menu.Target>
+
+        <Menu.Dropdown>
+          <Menu.Item
+            color="red"
+            leftSection={<IconLogout size={16} />}
+            onClick={handleLogout}
+          >
+            ログアウト
+          </Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+
+      <LogoutConfirmationModal
+        onClose={handleCancelLogout}
+        onConfirm={handleConfirmLogout}
+        opened={logoutModalOpened}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

ユーザーアバターをクリックした際のログアウト機能を実装しました。

### 実装内容

- **LogoutConfirmationModal** コンポーネント
  - Mantineダイアログによる確認メッセージ表示
  - 赤色ログアウトボタン（ログアウトアイコン付き）
  - キャンセルボタン
  - ESCキーと×ボタンによる閉じる機能
  - 包括的なテストスイート（8テスト）

- **UserAvatarMenu** コンポーネント
  - ユーザーアバターをクリックするとドロップダウンメニュー表示
  - 赤文字+ログアウトアイコン付きログアウトオプション
  - NextAuth.js signOut機能の統合
  - ログアウト確認モーダルとの統合
  - 包括的なテストスイート（10テスト）

- **Header** コンポーネントの更新
  - 従来のAvatarコンポーネントをUserAvatarMenuに置き換え
  - 既存の機能とテストを維持

### テスト結果

- 全826テスト成功
- TDD（Test-Driven Development）手法による実装
- 新規テスト18件追加（LogoutConfirmationModal: 8件、UserAvatarMenu: 10件）
- 既存テスト維持（Header: 9件成功）

### 技術仕様

- **UI フレームワーク**: Mantine (Menu, Modal, Avatar, Button)
- **認証**: NextAuth.js signOut
- **アイコン**: Tabler Icons (IconLogout)
- **テスト**: Vitest + React Testing Library
- **型安全性**: TypeScript strict mode

### 動作フロー

1. ユーザーがヘッダーのアバターをクリック
2. ドロップダウンメニューが表示され、「ログアウト」オプションを表示
3. ログアウトをクリックすると確認モーダルが表示
4. 「ログアウト」ボタンクリックでNextAuth.jsのsignOut実行
5. ユーザーがログイン画面にリダイレクト

### 品質チェック

- ✅ yarn format
- ✅ yarn lint
- ✅ yarn typecheck  
- ✅ yarn test
- ✅ pre-commit hooks

## Test plan

- [x] ユーザーアバターをクリックしてドロップダウンメニューが表示される
- [x] ログアウトオプションが赤文字+アイコンで表示される
- [x] ログアウトクリックで確認モーダルが表示される
- [x] 確認モーダルでログアウト実行される
- [x] キャンセルボタンでモーダルが閉じる
- [x] ESCキーでモーダルが閉じる
- [x] 既存機能が影響を受けない
- [x] 全テストが成功する

🤖 Generated with [Claude Code](https://claude.ai/code)