### PR TITLE
feat: モバイル用ハンバーガーメニューを実装

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { AppShell } from '@mantine/core'
-import { useMediaQuery } from '@mantine/hooks'
+import { useDisclosure, useMediaQuery } from '@mantine/hooks'
 
 import { Header } from '@/components/layout/header'
 import { TodoDetailDrawer } from '@/components/todo/todo-detail-drawer'
@@ -24,6 +24,10 @@ export default function TodoPage() {
   const { isDrawerOpen, selectedTodo, setDrawerOpen, setSelectedTodo } =
     useUiStore()
 
+  // ナビゲーションメニューの開閉状態管理
+  const [navbarOpened, { close: closeNavbar, toggle: toggleNavbar }] =
+    useDisclosure()
+
   // デスクトップサイズの判定 (992px以上をデスクトップとして扱う)
   const isDesktop = useMediaQuery('(min-width: 62em)')
 
@@ -44,12 +48,16 @@ export default function TodoPage() {
           width: { md: 400, sm: 300 },
         }}
         header={{ height: 60 }}
-        navbar={{ breakpoint: 'sm', collapsed: { mobile: true }, width: 280 }}
+        navbar={{
+          breakpoint: 'sm',
+          collapsed: { mobile: !navbarOpened },
+          width: 280,
+        }}
         padding="md"
       >
         {/* ヘッダー */}
         <AppShell.Header>
-          <Header />
+          <Header navbarOpened={navbarOpened} toggleNavbar={toggleNavbar} />
         </AppShell.Header>
 
         {/* 左サイドバー - フィルタ */}
@@ -58,7 +66,9 @@ export default function TodoPage() {
         </AppShell.Navbar>
 
         {/* メインコンテンツ - タスク一覧 */}
-        <AppShell.Main>
+        <AppShell.Main
+          onClick={!isDesktop && navbarOpened ? closeNavbar : undefined}
+        >
           <TodoMainContent />
         </AppShell.Main>
 

--- a/src/components/layout/header.test.tsx
+++ b/src/components/layout/header.test.tsx
@@ -113,7 +113,7 @@ describe('Header', () => {
 
     // Assert
     const buttons = screen.getAllByRole('button')
-    expect(buttons).toHaveLength(2) // 設定ボタンとヘルプボタン
+    expect(buttons).toHaveLength(3) // ハンバーガーボタン、設定ボタン、ヘルプボタン
   })
 
   it('ユーザーが設定されている場合、ユーザー名のイニシャルでAvatarを表示する', () => {

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, TextInput, Title } from '@mantine/core'
+import { ActionIcon, Burger, Group, TextInput, Title } from '@mantine/core'
 import { IconHelp, IconSearch, IconSettings } from '@tabler/icons-react'
 
 import { UserAvatarMenu } from '@/components/layout/user-avatar-menu'
@@ -6,16 +6,22 @@ import { useClientOnly } from '@/hooks/use-client-only'
 import { generateUserInitials } from '@/lib/utils'
 import { useUserStore } from '@/stores/user-store'
 
+interface HeaderProps {
+  navbarOpened?: boolean
+  toggleNavbar?: () => void
+}
+
 /**
  * ヘッダーコンポーネント
  *
  * アプリケーションのヘッダー部分を表示します。
+ * - ハンバーガーメニュー（モバイル用）
  * - アプリケーション名「To Do」
  * - 検索バー
  * - 設定とヘルプボタン
  * - ユーザー情報とアバター
  */
-export function Header() {
+export function Header({ navbarOpened = false, toggleNavbar }: HeaderProps) {
   const { user } = useUserStore()
   const isClient = useClientOnly()
 
@@ -36,6 +42,13 @@ export function Header() {
   return (
     <Group h="100%" justify="space-between" px="md">
       <Group>
+        <Burger
+          aria-label="ナビゲーションメニューを開く"
+          hiddenFrom="sm"
+          onClick={toggleNavbar}
+          opened={navbarOpened}
+          size="sm"
+        />
         <Title c="blue" order={3}>
           To Do
         </Title>


### PR DESCRIPTION
- Headerコンポーネントにハンバーガーアイコンを追加
- モバイルサイズ（sm未満）でのみ表示
- ナビゲーション開閉状態を管理
- メインエリアクリックでサイドバーを閉じる機能
- アクセシビリティ対応（aria-label）
- レスポンシブなフィルターメニューアクセスを提供

🤖 Generated with [Claude Code](https://claude.ai/code)