### PR TITLE
Fix test imports for Mantine provider

### DIFF
--- a/src/components/settings/api-key-create-modal.test.tsx
+++ b/src/components/settings/api-key-create-modal.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ApiKeyCreateModal } from './api-key-create-modal'
 
 import type { ApiKeyCreateResponse } from '@/schemas/api-key'
+
+import { render, screen } from '@/test-utils'
 
 /**
  * APIキー作成モーダル テスト

--- a/src/components/settings/api-key-display-modal.test.tsx
+++ b/src/components/settings/api-key-display-modal.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import { ApiKeyDisplayModal } from './api-key-display-modal'
 
 import type { ApiKeyCreateResponse } from '@/schemas/api-key'
+
+import { render, screen } from '@/test-utils'
 
 /**
  * APIキー表示モーダルコンポーネント テスト

--- a/src/components/settings/api-key-list.test.tsx
+++ b/src/components/settings/api-key-list.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ApiKeyList } from './api-key-list'
 
 import type { ApiKeyResponse } from '@/schemas/api-key'
+
+import { render, screen } from '@/test-utils'
 
 /**
  * APIキー一覧コンポーネント テスト

--- a/src/components/settings/settings-sidebar.test.tsx
+++ b/src/components/settings/settings-sidebar.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { SettingsSidebar } from './settings-sidebar'
+
+import { render, screen } from '@/test-utils'
 
 /**
  * 設定サイドバーコンポーネント テスト


### PR DESCRIPTION
## Summary
- adjust rendering in several settings tests to include Mantine provider

## Testing
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- `yarn test` *(fails: 41 failed, 931 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687281bb86c0832799df4b21de6c821e